### PR TITLE
fix pkg-config --cflags com_err 

### DIFF
--- a/lib/et/com_err.pc.in
+++ b/lib/et/com_err.pc.in
@@ -7,6 +7,6 @@ Name: com_err
 Description: Common error description library
 Version: @E2FSPROGS_VERSION@
 Requires:
-Cflags: -I${includedir}/et
+Cflags: -I${includedir}
 Libs: -L${libdir} -lcom_err
 Libs.private: @SEM_INIT_LIB@


### PR DESCRIPTION
compile_et puts #include <et/com_err.h> in
generated header files so pkg-config --cflags
com_err should provide the path to the directory
containing et/.
