### PR TITLE
adding return value checks to fsync() calls

### DIFF
--- a/lib/ext2fs/unix_io.c
+++ b/lib/ext2fs/unix_io.c
@@ -912,7 +912,9 @@ static errcode_t unix_flush(io_channel channel)
 #ifndef NO_IO_CACHE
 	retval = flush_cached_blocks(channel, data, 0);
 #endif
-	fsync(data->dev);
+	if (fsync(data->dev) == -1)
+		return errno;
+
 	return retval;
 }
 

--- a/misc/filefrag.c
+++ b/misc/filefrag.c
@@ -299,8 +299,11 @@ static int filefrag_fibmap(int fd, int blk_shift, int *num_extents,
 		fm_ext.fe_flags = FIEMAP_EXTENT_MERGED;
 	}
 
-	if (sync_file)
-		fsync(fd);
+	if (sync_file) {
+		int rc = fsync(fd);
+		if (rc < 0)
+			return rc;
+	}
 
 	for (i = 0, logical = 0, *num_extents = 0, count = last_block = 0;
 	     i < numblocks;


### PR DESCRIPTION
Hi,

I recently ran into a problem where pwrite() calls to my block device (an nbd server) were failing, but mke2fs did not inform me of the error (and exited return status 0).

It turns out the pwrite() calls aren't "failing" as far as mke2fs can see, however it can see that the final fsync() call is failing (as revealed by strace).  It turns out that final fsync() return value isn't being checked, which is why mke2fs is not reporting failure.

I searched the e2fsprogs code base and only found two instances of the return value of fsync() not being checked.  This patch aims to address those.  The overall goal is that if there is an fsync() error, mke2fs should exit non-zero.

As I'm not familiar with the overall error handling mechanisms in e2fsprogs, feel free to adjust this patch as needed to suit the local convention.

Thanks!
