### PR TITLE
mke2fs: Additional values for -U option

### DIFF
--- a/misc/mke2fs.c
+++ b/misc/mke2fs.c
@@ -2914,7 +2914,14 @@ int main (int argc, char *argv[])
 	 * Parse or generate a UUID for the filesystem
 	 */
 	if (fs_uuid) {
-		if (uuid_parse(fs_uuid, fs->super->s_uuid) !=0) {
+		if ((strcasecmp(fs_uuid, "null") == 0) ||
+		    (strcasecmp(fs_uuid, "clear") == 0)) {
+			uuid_clear(fs->super->s_uuid);
+		} else if (strcasecmp(fs_uuid, "time") == 0) {
+			uuid_generate_time(fs->super->s_uuid);
+		} else if (strcasecmp(fs_uuid, "random") == 0) {
+			uuid_generate(fs->super->s_uuid);
+		} else if (uuid_parse(fs_uuid, fs->super->s_uuid) !=0) {
 			com_err(device_name, 0, "could not parse UUID: %s\n",
 				fs_uuid);
 			exit(1);


### PR DESCRIPTION
Allow "null", "clear", "random", or "time" as well as a valid UUID
for the -U option. This makes mke2fs -U consistent with tune2fs -U.

Signed-off-by: Drew Davenport <ddavenport@google.com>