### PR TITLE
chattr/lsattr: expose FS_NOCOMP_FL (aka EXT2_NOCOMPR_FL)

### DIFF
--- a/lib/e2p/pf.c
+++ b/lib/e2p/pf.c
@@ -47,6 +47,7 @@ static struct flags_name flags_array[] = {
 	{ FS_NOCOW_FL, "C", "No_COW" },
 	{ EXT4_INLINE_DATA_FL, "N", "Inline_Data" },
 	{ EXT4_PROJINHERIT_FL, "P", "Project_Hierarchy" },
+	{ EXT2_NOCOMPR_FL, "m", "Dont_Compress" },
 	{ 0, NULL, NULL }
 };
 
@@ -74,4 +75,3 @@ void print_flags (FILE * f, unsigned long flags, unsigned options)
 	if (long_opt && first)
 		fputs("---", f);
 }
-

--- a/misc/chattr.1.in
+++ b/misc/chattr.1.in
@@ -23,13 +23,13 @@ chattr \- change file attributes on a Linux file system
 .B chattr
 changes the file attributes on a Linux file system.
 .PP
-The format of a symbolic mode is +-=[aAcCdDeijsStTu].
+The format of a symbolic mode is +-=[aAcCdDeijmPsStTu].
 .PP
 The operator '+' causes the selected attributes to be added to the
 existing attributes of the files; '-' causes them to be removed; and '='
 causes them to be the only attributes that the files have.
 .PP
-The letters 'aAcCdDeijsStTu' select the new attributes for the files:
+The letters 'aAcCdDeijmPsStTu' select the new attributes for the files:
 append only (a),
 no atime updates (A),
 compressed (c),
@@ -39,6 +39,7 @@ synchronous directory updates (D),
 extent format (e),
 immutable (i),
 data journalling (j),
+don't compress (m),
 project hierarchy (P),
 secure deletion (s),
 synchronous updates (S),
@@ -147,6 +148,9 @@ filesystem is mounted with the "data=journal" option all file data
 is already journalled and this attribute has no effect.  Only
 the superuser or a process possessing the CAP_SYS_RESOURCE
 capability can set or clear this attribute.
+.PP
+A file with the 'm' attribute is excluded from compression on file
+systems that support per-file compression.
 .PP
 A file with the 'N' attribute set indicates that the file has data
 stored inline, within the inode itself. It may not be set or reset using

--- a/misc/chattr.c
+++ b/misc/chattr.c
@@ -102,6 +102,7 @@ static const struct flags_char flags_array[] = {
 	{ EXT2_DIRSYNC_FL, 'D' },
 	{ EXT2_APPEND_FL, 'a' },
 	{ EXT2_COMPR_FL, 'c' },
+	{ EXT2_NOCOMPR_FL, 'm' },
 	{ EXT2_NODUMP_FL, 'd' },
 	{ EXT4_EXTENTS_FL, 'e'},
 	{ EXT2_IMMUTABLE_FL, 'i' },


### PR DESCRIPTION
This adds support for setting/querying the FS_NOCOMP_FL/EXT2_NOCOMPR_FL
file flag to chattr/lsattr. I picked the character "m" because it was
so far unused and all other characters that were more obvious candidates
were already taken.

This also updates the man page a bit, adding the projinherit flag to two
lists where it was missing so far.

The flag is available on btrfs, and with this patch it is possible to
manage it correctly.

Signed-off-by: Lennart Poettering <lennart@poettering.net>