### PR TITLE
New options for badblocks utility

### DIFF
--- a/misc/badblocks.8.in
+++ b/misc/badblocks.8.in
@@ -5,7 +5,11 @@ badblocks \- search a device for bad blocks
 .SH SYNOPSIS
 .B badblocks
 [
-.B \-svwnfBX
+.B \-svwnfBXP
+]
+[
+.B \-a
+.I alarm_interval
 ]
 [
 .B \-b
@@ -82,6 +86,9 @@ and
 .B mke2fs
 programs.
 .SH OPTIONS
+.TP
+.BI \-a " alarm_interval"
+Interval (in seconds) used for displaying status updates. The default is 1.
 .TP
 .BI \-b " block_size"
 Specify the size of blocks in bytes.  The default is 1024.
@@ -198,6 +205,13 @@ option, as they are mutually exclusive.
 .TP
 .B \-B
 Use buffered I/O and do not use Direct I/O, even if it is available.
+.TP
+.B \-P
+Display status in machine parseable format. The data is comma separated and
+LF terminated to make it easier to parsing by external applications. The
+data format is:
+% completed, time elapsed, read errors, write errors, corruption errors.
+Example: 10.06, 1:22, 0, 0, 0
 .TP
 .B \-X
 Internal flag only to be used by

--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -226,23 +226,23 @@ static void print_status(void)
 	wchar_t wline_buf[128];
 #endif
 	int len;
-    char format_str[128];
+	char format_str[128];
 
-    if (parseable_output) {
-        strcpy(format_str, "%6.2f, %s, %d, %d, %d");
-    } else {
-        strcpy(format_str, "%6.2f%% done, %s elapsed. (%d/%d/%d errors)");
-    }
+	if (parseable_output) {
+		strcpy(format_str, "%6.2f, %s, %d, %d, %d");
+	} else {
+		strcpy(format_str, "%6.2f%% done, %s elapsed. (%d/%d/%d errors)");
+	}
 
 	gettimeofday(&time_end, 0);
 	len = snprintf(line_buf, sizeof(line_buf), 
-		       _(format_str),
-		       calc_percent((unsigned long) currently_testing,
-				    (unsigned long) num_blocks), 
-		       time_diff_format(&time_end, &time_start, diff_buf),
-		       num_read_errors,
-		       num_write_errors,
-		       num_corruption_errors);
+			_(format_str),
+			calc_percent((unsigned long) currently_testing,
+			(unsigned long) num_blocks),
+			time_diff_format(&time_end, &time_start, diff_buf),
+			num_read_errors,
+			num_write_errors,
+			num_corruption_errors);
 #ifdef HAVE_MBSTOWCS
 	mbstowcs(wline_buf, line_buf, sizeof(line_buf));
 	len = wcswidth(wline_buf, sizeof(line_buf));
@@ -250,13 +250,13 @@ static void print_status(void)
 		len = strlen(line_buf); /* Should never happen... */
 #endif
 	fputs(line_buf, stderr);
-    if (!parseable_output) {
-	    memset(line_buf, '\b', len);
-	    line_buf[len] = 0;
-	    fputs(line_buf, stderr);	
-    } else {
-        fputs("\n", stderr);
-    }
+	if (!parseable_output) {
+		memset(line_buf, '\b', len);
+		line_buf[len] = 0;
+		fputs(line_buf, stderr);
+	} else {
+		fputs("\n", stderr);
+	}
 	fflush (stderr);
 }
 

--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -1196,16 +1196,16 @@ int main (int argc, char ** argv)
 		case 'X':
 			exclusive_ok++;
 			break;
-        case 'P':
-            parseable_output = 1;
-            break;
-        case 'a':
+		case 'P':
+			parseable_output = 1;
+			break;
+		case 'a':
 			alarm_interval = parse_uint(optarg, "status alarm interval (seconds)");
-            if (alarm_interval == 0) {
-                com_err(program_name, 0, "%s",
-                    _("Minimum alarm interval is 1 second"));
-                exit(1);
-            }
+			if (alarm_interval == 0) {
+				com_err(program_name, 0, "%s",
+					_("Minimum alarm interval is 1 second"));
+				exit(1);
+			}
 			break;
 		default:
 			usage();


### PR DESCRIPTION
We have a need to run badblocks and monitor its output from inside another utility and found it useful to alter the status output to be more parseable and control the rate at which the status updates are printed. Others may find this useful.

    New command line options for badblocks:
       -a alarm_interval
       -P
    alarm_interval controls the frequency of the status update output
    -P makes the output more parseable by external programs (comman separated, LF terminated)
    
    signed-off-by: Wyllys Ingersoll <wyllys.ingersoll@keepertech.com>
