### PR TITLE
fix printf format %d on ext2_ino_t

### DIFF
--- a/debugfs/debugfs.c
+++ b/debugfs/debugfs.c
@@ -2116,7 +2116,7 @@ void do_idump(int argc, char *argv[])
 	err = ext2fs_read_inode_full(current_fs, ino,
 				     (struct ext2_inode *)buf, isize);
 	if (err) {
-		com_err(argv[0], err, "while reading inode %d", ino);
+		com_err(argv[0], err, "while reading inode %u", ino);
 		goto err;
 	}
 

--- a/e2fsck/super.c
+++ b/e2fsck/super.c
@@ -204,7 +204,7 @@ static int release_inode_blocks(e2fsck_t ctx, ext2_ino_t ino,
 				      block_buf, release_inode_block, &pb);
 	if (retval) {
 		com_err("release_inode_blocks", retval,
-			_("while calling ext2fs_block_iterate for inode %d"),
+			_("while calling ext2fs_block_iterate for inode %u"),
 			ino);
 		return 1;
 	}
@@ -227,7 +227,7 @@ static int release_inode_blocks(e2fsck_t ctx, ext2_ino_t ino,
 		}
 		if (retval) {
 			com_err("release_inode_blocks", retval,
-		_("while calling ext2fs_adjust_ea_refcount2 for inode %d"),
+		_("while calling ext2fs_adjust_ea_refcount2 for inode %u"),
 				ino);
 			return 1;
 		}


### PR DESCRIPTION
`lib/ext2fs/ext2fs.h` contains `typedef __u32 ext2_ino_t`, so the format string should be `%u`