### PR TITLE
fit for the inodemap number which is not integer bytes

### DIFF
--- a/lib/ext2fs/blkmap64_rb.c
+++ b/lib/ext2fs/blkmap64_rb.c
@@ -758,6 +758,15 @@ static errcode_t rb_get_bmap_range(ext2fs_generic_bitmap bitmap,
 	}
 
 	memset(out, 0, (num + 7) >> 3);
+	if(num%8!=0) {
+		pos=num;
+		count =8-(num -((num>>3)<<3));
+		while (count > 0) {
+			ext2fs_fast_set_bit(pos, out);
+			pos++;
+			count--;
+		}
+	}
 
 	for (; parent != NULL; parent = next) {
 		next = ext2fs_rb_next(parent);

--- a/lib/ext2fs/rw_bitmaps.c
+++ b/lib/ext2fs/rw_bitmaps.c
@@ -115,19 +115,16 @@ static errcode_t write_bitmaps(ext2_filsys fs, int do_inode, int do_block)
 		if (csum_flag && ext2fs_bg_flags_test(fs, i, EXT2_BG_INODE_UNINIT)
 		    )
 			goto skip_this_inode_bitmap;
-
 		retval = ext2fs_get_inode_bitmap_range2(fs->inode_map,
-				ino_itr, inode_nbytes << 3, inode_buf);
+				ino_itr, EXT2_INODES_PER_GROUP(fs->super), inode_buf);
 		if (retval)
 			goto errout;
-
 		retval = ext2fs_inode_bitmap_csum_set(fs, i, inode_buf,
 						      inode_nbytes);
 		if (retval)
 			goto errout;
 		ext2fs_group_desc_csum_set(fs, i);
 		fs->flags |= EXT2_FLAG_DIRTY;
-
 		blk = ext2fs_inode_bitmap_loc(fs, i);
 		if (blk) {
 			retval = io_channel_write_blk64(fs->io, blk, 1,
@@ -138,7 +135,7 @@ static errcode_t write_bitmaps(ext2_filsys fs, int do_inode, int do_block)
 			}
 		}
 	skip_this_inode_bitmap:
-		ino_itr += inode_nbytes << 3;
+		ino_itr += EXT2_INODES_PER_GROUP(fs->super);
 
 	}
 	if (do_block) {
@@ -349,12 +346,12 @@ static errcode_t read_bitmaps(ext2_filsys fs, int do_inode, int do_block)
 				}
 			} else
 				memset(inode_bitmap, 0, inode_nbytes);
-			cnt = inode_nbytes << 3;
+			cnt = EXT2_INODES_PER_GROUP(fs->super);
 			retval = ext2fs_set_inode_bitmap_range2(fs->inode_map,
 					       ino_itr, cnt, inode_bitmap);
 			if (retval)
 				goto cleanup;
-			ino_itr += inode_nbytes << 3;
+			ino_itr += EXT2_INODES_PER_GROUP(fs->super);
 		}
 	}
 

--- a/misc/dumpe2fs.c
+++ b/misc/dumpe2fs.c
@@ -168,7 +168,7 @@ static void list_desc(ext2_filsys fs, int grp_only)
 		units = _("clusters");
 
 	block_nbytes = EXT2_CLUSTERS_PER_GROUP(fs->super) / 8;
-	inode_nbytes = EXT2_INODES_PER_GROUP(fs->super) / 8;
+	inode_nbytes = (EXT2_INODES_PER_GROUP(fs->super)+7) / 8;
 
 	if (fs->block_map)
 		block_bitmap = malloc(block_nbytes);
@@ -303,7 +303,7 @@ static void list_desc(ext2_filsys fs, int grp_only)
 		if (inode_bitmap) {
 			fputs(_("  Free inodes: "), stdout);
 			retval = ext2fs_get_inode_bitmap_range2(fs->inode_map,
-				 ino_itr, inode_nbytes << 3, inode_bitmap);
+				 ino_itr, EXT2_INODES_PER_GROUP(fs->super), inode_bitmap);
 			if (retval)
 				com_err("list_desc", retval,
 					"while reading inode bitmap");


### PR DESCRIPTION
 e2fsck  cannot fix the senario : the bytes of inode bitmap are not intergers.
for example, 1708 inodes, bitmap bytes are 1708/8=213.5
when the inode bitmap has some errors, this tool cannot fix it 