### PR TITLE
Test multiple blocks at once using badblocks when invoked by e2fsck

### DIFF
--- a/e2fsck/badblocks.c
+++ b/e2fsck/badblocks.c
@@ -73,7 +73,8 @@ void read_bad_blocks_file(e2fsck_t ctx, const char *bad_blocks_file,
 			goto fatal;
 		}
 	} else {
-		sprintf(buf, "badblocks -b %d -X %s%s%s %llu", fs->blocksize,
+		sprintf(buf, "badblocks -b %d -c %d -X %s%s%s %llu", fs->blocksize,
+			ctx->blocks_at_once,
 			(ctx->options & E2F_OPT_PREEN) ? "" : "-s ",
 			(ctx->options & E2F_OPT_WRITECHECK) ? "-n " : "",
 			fs->device_name, ext2fs_blocks_count(fs->super)-1);

--- a/e2fsck/e2fsck.c
+++ b/e2fsck/e2fsck.c
@@ -34,6 +34,7 @@ errcode_t e2fsck_allocate_context(e2fsck_t *ret)
 	context->ext_attr_ver = 2;
 	context->blocks_per_page = 1;
 	context->htree_slack_percentage = 255;
+	context->blocks_at_once = 64;
 
 	time_env = getenv("E2FSCK_TIME");
 	if (time_env)

--- a/e2fsck/e2fsck.h
+++ b/e2fsck/e2fsck.h
@@ -233,6 +233,7 @@ struct e2fsck_struct {
 	int	flags;		/* E2fsck internal flags */
 	int	options;
 	int	blocksize;	/* blocksize */
+	int blocks_at_once; /* for badblocks */
 	blk64_t	use_superblock;	/* sb requested by user */
 	blk64_t	superblock;	/* sb used to open fs */
 	blk64_t	num_blocks;	/* Total number of blocks */

--- a/e2fsck/unix.c
+++ b/e2fsck/unix.c
@@ -84,6 +84,7 @@ static void usage(e2fsck_t ctx)
 		" -n                   Make no changes to the filesystem\n"
 		" -y                   Assume \"yes\" to all questions\n"
 		" -c                   Check for bad blocks and add them to the badblock list\n"
+		" -K blocks_at_once    The number of blocks which are tested at a time when using badblocks. The default is 64.\n"
 		" -f                   Force checking even if filesystem is marked clean\n"));
 	fprintf(stderr, "%s", _(""
 		" -v                   Be verbose\n"
@@ -835,7 +836,7 @@ static errcode_t PRS(int argc, char *argv[], e2fsck_t *ret_ctx)
 
 	phys_mem_kb = get_memory_size() / 1024;
 	ctx->readahead_kb = ~0ULL;
-	while ((c = getopt(argc, argv, "panyrcC:B:dE:fvtFVM:b:I:j:P:l:L:N:SsDkz:")) != EOF)
+	while ((c = getopt(argc, argv, "panyrcC:B:dE:fvtFVM:b:I:j:P:l:L:N:SsDkz:K:")) != EOF)
 		switch (c) {
 		case 'C':
 			ctx->progress = e2fsck_update_progress;
@@ -901,6 +902,9 @@ static errcode_t PRS(int argc, char *argv[], e2fsck_t *ret_ctx)
 			if (cflag++)
 				ctx->options |= E2F_OPT_WRITECHECK;
 			ctx->options |= E2F_OPT_CHECKBLOCKS;
+			break;
+		case 'K':
+			ctx->blocks_at_once = atoi(optarg);
 			break;
 		case 'r':
 			/* What we do by default, anyway! */


### PR DESCRIPTION
When `e2fsck` is run with the `-c` option to use `badblocks` to find any bad blocks on the device, it does so without specifying the number of blocks to test at once.  This can cause a lot of seeks on mechanical hard drives and makes testing large drives incredibly slow.

This pull request adds an option `-K` to the `e2fsck` command to allow the number of blocks tested at once by `badblocks` to be specified when it is called by `e2fsck -c`.