### PR TITLE
When journal hint is out of sync with UUID, do not trigger full check

### DIFF
--- a/e2fsck/problem.c
+++ b/e2fsck/problem.c
@@ -369,7 +369,7 @@ static struct e2fsck_problem problem_table[] = {
 	{ PR_0_EXTERNAL_JOURNAL_HINT,
 	  /* xgettext:no-c-format */
 	  N_("@S hint for external superblock @s %X.  "),
-	     PROMPT_FIX, PR_PREEN_OK, 0, 0, 0 },
+	     PROMPT_FIX, PR_PREEN_OK | PR_NOT_A_FIX, 0, 0, 0 },
 
 	/* Adding dirhash hint to filesystem */
 	{ PR_0_DIRHASH_HINT,


### PR DESCRIPTION
Currently, when the superblock's external journal hint is out of sync with the journal's UUID, fsck fixes the journal hint and marks this as a "fix", triggering the full fsck run. This longer run is unnecessary since the major / minor numbers can become out of sync in the course of normal, error-free operation.