### PR TITLE
OSS-Fuzz integration

### DIFF
--- a/tests/fuzz/build.sh
+++ b/tests/fuzz/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -eu
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# build project
+case "$SANITIZER" in
+  "address") configure_flags="--enable-addrsan" ;;
+  "undefined") configure_flags="--enable-ubsan" ;;
+  "*") configure_flags="" ;;
+esac
+
+$SRC/e2fsprogs/configure $configure_flags
+make -j$(nproc) all
+
+# build fuzzers
+for fuzzer in $(find $SRC/e2fsprogs/tests/fuzz -name '*_fuzzer.cc'); do
+  fuzzer_basename=$(basename -s .cc $fuzzer)
+  $CXX $CXXFLAGS \
+    $LIB_FUZZING_ENGINE \
+    -I $SRC/e2fsprogs/lib \
+    $fuzzer \
+    -L'./lib/ext2fs' -lext2fs \
+    -L'./lib/et' -lcom_err \
+    -o $OUT/$fuzzer_basename
+done

--- a/tests/fuzz/ext2fs_check_directory_fuzzer.cc
+++ b/tests/fuzz/ext2fs_check_directory_fuzzer.cc
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    retval = ext2fs_check_directory(fs, EXT2_ROOT_INO);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_image_bitmap_read_fuzzer.cc
+++ b/tests/fuzz/ext2fs_image_bitmap_read_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_image_bitmap_read(fs, fd, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_image_bitmap_write_fuzzer.cc
+++ b/tests/fuzz/ext2fs_image_bitmap_write_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_image_bitmap_write(fs, fd, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_image_inode_read_fuzzer.cc
+++ b/tests/fuzz/ext2fs_image_inode_read_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_image_inode_read(fs, fd, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_image_inode_write_fuzzer.cc
+++ b/tests/fuzz/ext2fs_image_inode_write_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_image_inode_write(fs, fd, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_image_super_read_fuzzer.cc
+++ b/tests/fuzz/ext2fs_image_super_read_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_image_super_read(fs, fd, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_image_super_write_fuzzer.cc
+++ b/tests/fuzz/ext2fs_image_super_write_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_image_super_write(fs, fd, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_open_fuzzer.cc
+++ b/tests/fuzz/ext2fs_open_fuzzer.cc
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  ext2fs_close(fs);
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_read_block_bitmap_fuzzer.cc
+++ b/tests/fuzz/ext2fs_read_block_bitmap_fuzzer.cc
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    retval = ext2fs_read_block_bitmap(fs);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_read_dir_block2_fuzzer.cc
+++ b/tests/fuzz/ext2fs_read_dir_block2_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_read_dir_block2(fs, 0, buf, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_read_dir_block3_fuzzer.cc
+++ b/tests/fuzz/ext2fs_read_dir_block3_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_read_dir_block3(fs, 0, buf, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_read_dir_block_fuzzer.cc
+++ b/tests/fuzz/ext2fs_read_dir_block_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_read_dir_block(fs, 0, buf);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_read_inode_bitmap_fuzzer.cc
+++ b/tests/fuzz/ext2fs_read_inode_bitmap_fuzzer.cc
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    retval = ext2fs_read_inode_bitmap(fs);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_write_dir_block2_fuzzer.cc
+++ b/tests/fuzz/ext2fs_write_dir_block2_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_write_dir_block2(fs, 0, buf, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_write_dir_block3_fuzzer.cc
+++ b/tests/fuzz/ext2fs_write_dir_block3_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_write_dir_block3(fs, 0, buf, 0);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}

--- a/tests/fuzz/ext2fs_write_dir_block_fuzzer.cc
+++ b/tests/fuzz/ext2fs_write_dir_block_fuzzer.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "ext2fs/ext2fs.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static const char* pattern = "/dev/shm/ext2XXXXXX";
+  int fd;
+  char* fname;
+
+  // Write our data to a temp file.
+  fname = strdup(pattern);
+  fd = mkstemp(fname);
+  write(fd, data, size);
+  close(fd);
+
+  ext2_filsys fs;
+  errcode_t retval = ext2fs_open(
+      fname,
+      0, 0, 0,
+      unix_io_manager,
+      &fs);
+
+  if (!retval) {
+    void *buf;
+    retval = ext2fs_write_dir_block(fs, 0, buf);
+    ext2fs_close(fs);
+  }
+
+  unlink(fname);
+  free(fname);
+  return 0;
+}


### PR DESCRIPTION
Adding a `tests/fuzz` folder in order to facilitate [OSS-Fuzz](https://github.com/google/oss-fuzz) integration. With this, we can continuously fuzz test e2fsprogs in order to uncover otherwise difficult-to-detect issues.

As per `e2fsprogs/SUBMITTING-PATCHES`, I've included the following line:
Signed-off-by: Ravi Jotwani <rjotwani@google.com>