### PR TITLE
e4crypt: if salt is explicitly provided to add_key, then use it

### DIFF
--- a/misc/e4crypt.8.in
+++ b/misc/e4crypt.8.in
@@ -48,7 +48,9 @@ values are 4, 8, 16, and 32.
 If one or more directory paths are specified, e4crypt will try to
 set the policy of those directories to use the key just added by the
 .B add_key
-command.
+command.  If a salt was explicitly specified, then it will be used
+by the policy of those directories.  Otherwise a directory-specific
+default salt will be used.
 .TP
 .B e4crypt get_policy \fIpath\fR ...
 Print the policy for the directories specified on the command line.

--- a/misc/e4crypt.c
+++ b/misc/e4crypt.c
@@ -652,6 +652,7 @@ static void do_help(int argc, char **argv, const struct cmd_desc *cmd);
 static void do_add_key(int argc, char **argv, const struct cmd_desc *cmd)
 {
 	struct salt *salt;
+	struct salt *explicit_salt = NULL;
 	char *keyring = NULL;
 	int i, opt, pad = 4;
 	unsigned j;
@@ -666,8 +667,13 @@ static void do_add_key(int argc, char **argv, const struct cmd_desc *cmd)
 			pad = atoi(optarg);
 			break;
 		case 'S':
+			if (explicit_salt) {
+				fputs("May only provide -S once\n", stderr);
+				exit(1);
+			}
 			/* Salt value for passphrase. */
 			parse_salt(optarg, 0);
+			explicit_salt = salt_list;
 			break;
 		case 'v':
 			options |= OPT_VERBOSE;
@@ -703,7 +709,7 @@ static void do_add_key(int argc, char **argv, const struct cmd_desc *cmd)
 		insert_key_into_keyring(keyring, salt);
 	}
 	if (optind != argc)
-		set_policy(NULL, pad, argc, argv, optind);
+		set_policy(explicit_salt, pad, argc, argv, optind);
 	clear_secrets();
 	exit(0);
 }


### PR DESCRIPTION
Providing -S and a path to 'add_key' previously exhibit an unintuitive
behavior: instead of using the salt explicitly provided by the user,
e4crypt would use the salt obtained via EXT4_IOC_GET_ENCRYPTION_PWSALT
on the path. This was because set_policy() was still called with NULL
as salt.

With this change we now remember the explicitly provided salt (if any)
and use it as argument for set_policy().

Eventually

e4crypt add_key -S s:my-spicy-salt /foo

will now actually use 'my-spicy-salt' and not something else as salt
for the policy set on /foo.

Signed-off-by: Florian Schmaus <flo@geekplace.eu>