### PR TITLE
Clarify in e4crypt man page that -S is an optional argument

### DIFF
--- a/misc/e4crypt.8.in
+++ b/misc/e4crypt.8.in
@@ -2,7 +2,7 @@
 .SH NAME
 e4crypt \- ext4 filesystem encryption utility
 .SH SYNOPSIS
-.B e4crypt add_key -S \fR[\fB -k \fIkeyring\fR ] [\fB-v\fR] [\fB-q\fR] \fR[\fB -p \fIpad\fR ] [ \fIpath\fR ... ]
+.B e4crypt add_key \fR[\fB-vq\fR] [\fB-S\fI salt\fR ] [\fB-k \fIkeyring\fR ] [\fB -p \fIpad\fR ] [ \fIpath\fR ... ]
 .br
 .B e4crypt new_session
 .br


### PR DESCRIPTION
The Backus-Naur Form (BNF) of the synopsis of 'add_key' does currently
not state that the -S parameter takes an *mandatory* argument, while
the BNF found in the commands section of the man page does. The square
brackets around the optional parameter are also missing.

synopsis:
e4crypt add_key -S [ -k keyring ] [-v] [-q] [ -p pad ] [ path ... ]

commands:
e4crypt add_key [-vq] [-S salt ] [-k keyring ] [ -p pad ] [ path ... ]

This simply copies the add_key BNF from he commands section into the
synopsis.

Signed-off-by: Florian Schmaus <flo@geekplace.eu>