### PR TITLE
libext2fs: Remove the superfluous break

### DIFF
--- a/lib/ext2fs/ext_attr.c
+++ b/lib/ext2fs/ext_attr.c
@@ -626,7 +626,6 @@ static errcode_t convert_disk_buffer_to_posix_acl(const void *value, size_t size
 		default:
 			ext2fs_free_mem(&out);
 			return EINVAL;
-			break;
 		}
 		entry++;
 	}


### PR DESCRIPTION
Remove the superfuous break, as there is a 'return' before it.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>