### PR TITLE
chattr: Remove the superfluous break

### DIFF
--- a/misc/chattr.c
+++ b/misc/chattr.c
@@ -202,7 +202,6 @@ static int decode_arg (int * i, int argc, char ** argv)
 		break;
 	default:
 		return EOF;
-		break;
 	}
 	return 1;
 }


### PR DESCRIPTION
Remove the superfuous break, as there is a 'return' before it.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>