### PR TITLE
fix up check for hardlinks not accurate

### DIFF
--- a/misc/create_inode.h
+++ b/misc/create_inode.h
@@ -11,7 +11,7 @@
 struct hdlink_s
 {
 	dev_t src_dev;
-	ino_t src_ino;
+	ext2_ino_t src_ino;
 	ext2_ino_t dst_ino;
 };
 


### PR DESCRIPTION
While file has a large inode number, mkfs.ext4 could not parse
hardlink.

$ ls -il rootfs_ota/a rootfs_ota/boot/b rootfs_ota/boot/c
11026675846 -rw-r--r-- 3 hjia users 0 Jul 20 17:44 rootfs_ota/a
11026675846 -rw-r--r-- 3 hjia users 0 Jul 20 17:44 rootfs_ota/boot/b
11026675846 -rw-r--r-- 3 hjia users 0 Jul 20 17:44 rootfs_ota/boot/c

$ truncate -s 1M rootfs_ota.ext4

$ mkfs.ext4 -F -i 8192 rootfs_ota.ext4 -L otaroot -U fd5f8768-c779-4dc9-adde-165a3d863349 -d rootfs_ota

$ mkdir mnt && sudo mount rootfs_ota.ext4 mnt 

$ ls -il mnt/rootfs_ota/a mnt/rootfs_ota/boot/b
12 -rw-r--r-- 1 hjia users 0 Jul 20 17:44 mnt/a
14 -rw-r--r-- 1 hjia users 0 Jul 20 17:44 mnt/boot/b
15 -rw-r--r-- 1 hjia users 0 Jul 20 17:44 mnt/boot/c

After applying this fix 
$ ls -il mnt/rootfs_ota/a mnt/rootfs_ota/boot/b
12 -rw-r--r-- 3 hjia users 0 Jul 20 17:44 mnt/a
12 -rw-r--r-- 3 hjia users 0 Jul 20 17:44 mnt/boot/b
12 -rw-r--r-- 3 hjia users 0 Jul 20 17:44 mnt/boot/c