### PR TITLE
chattr.1: improve attributes description to btrfs

### DIFF
--- a/misc/chattr.1.in
+++ b/misc/chattr.1.in
@@ -96,7 +96,8 @@ A file with the 'c' attribute set is automatically compressed on the disk
 by the kernel.  A read from this file returns uncompressed data.  A write to
 this file compresses data before storing them on the disk.  Note: please
 make sure to read the bugs and limitations section at the end of this
-document.
+document.  (Note: For btrfs, If the 'c' flag is set, then the 'C' flag
+cannot be set. Also conflicts with btrfs mount option 'nodatasum')
 .TP
 .B C
 A file with the 'C' attribute set will not be subject to copy-on-write
@@ -106,7 +107,8 @@ set on new or empty files.  If it is set on a file which already has
 data blocks, it is undefined when the blocks assigned to the file will
 be fully stable.  If the 'C' flag is set on a directory, it will have no
 effect on the directory, but new files created in that directory will
-have the No_COW attribute set.)
+have the No_COW attribute set. If the 'C' flag is set, then the 'c' flag
+cannot be set.)
 .TP
 .B d
 A file with the 'd' attribute set is not a candidate for backup when the


### PR DESCRIPTION
- `c`: for btrfs, compression are conflicts with nodatacow and nodatasum
- `C`: for btrfs, nodatacow is conflict with compression

ref:
- https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs(5)#MOUNT_OPTIONS
- https://www.spinics.net/lists/linux-btrfs/msg103219.html