### PR TITLE
create_inode: Find subdirectory in do_write_internal

### DIFF
--- a/tests/t_write_subdirectory/name
+++ b/tests/t_write_subdirectory/name
@@ -1,0 +1,1 @@
+debugfs write creates file in subdirectory

--- a/tests/t_write_subdirectory/script
+++ b/tests/t_write_subdirectory/script
@@ -1,0 +1,29 @@
+FSCK_OPT=-nf
+
+$MKE2FS -q -F -o Linux -I 256 -b 4096 $TMPFILE 10000 > $test_name.log 2>&1
+status=$?
+if [ "$status" != 0 ] ; then
+	echo "mke2fs failed" > $test_name.failed
+	echo "$test_name: $test_description: failed"
+	return $status
+fi
+
+touch $TMPFILE.1
+cat <<- EOF | $DEBUGFS -w $TMPFILE >> $test_name.log 2>&1
+	mkdir aaa
+	mkdir aaa/bbb
+	write $TMPFILE.1 aaa/bbb/ccc
+EOF
+rm -f $TMPFILE.1
+
+$FSCK $FSCK_OPT $TMPFILE >> $test_name.log 2>&1
+status=$?
+if [ "$status" = 0 ] ; then
+	echo "$test_name: $test_description: ok"
+	touch $test_name.ok
+else
+	echo "e2fsck with failed with $status" > $test_name.failed
+	echo "$test_name: $test_description: failed"
+	return $status
+fi
+rm -f $TMPFILE


### PR DESCRIPTION
https://github.com/tytso/e2fsprogs/issues/61

Follow the example in do_mkdir_internal, and do_symlink_internal,
and find the correct parent directory if the destination
is not just a plain basename.

Signed-off-by: Earl Chew <earl_chew@yahoo.com>