### PR TITLE
Fix 1.46.2 regressions

### DIFF
--- a/lib/ext2fs/unix_io.c
+++ b/lib/ext2fs/unix_io.c
@@ -311,10 +311,10 @@ bounce_read:
 			size += really_read;
 			goto short_read;
 		}
-		actual = size;
-		if (actual > align_size)
-			actual = align_size;
-		actual -= offset;
+		if ((actual + offset) > align_size)
+			actual = align_size - offset;
+		if (actual > size)
+			actual = size;
 		memcpy(buf, data->bounce + offset, actual);
 
 		really_read += actual;
@@ -455,9 +455,10 @@ bounce_write:
 			}
 		}
 		actual = size;
-		if (actual > align_size)
-			actual = align_size;
-		actual -= offset;
+		if ((actual + offset) > align_size)
+			actual = align_size - offset;
+		if (actual > size)
+			actual = size;
 		memcpy(((char *)data->bounce) + offset, buf, actual);
 		if (ext2fs_llseek(data->dev, aligned_blk * align_size, SEEK_SET) < 0) {
 			retval = errno ? errno : EXT2_ET_LLSEEK_FAILED;

--- a/lib/ext2fs/unix_io.c
+++ b/lib/ext2fs/unix_io.c
@@ -398,7 +398,7 @@ static errcode_t raw_write_blk(io_channel channel,
 		mutex_lock(data, BOUNCE_MTX);
 		if (ext2fs_llseek(data->dev, location, SEEK_SET) < 0) {
 			retval = errno ? errno : EXT2_ET_LLSEEK_FAILED;
-			goto error_out;
+			goto error_unlock;
 		}
 		actual = write(data->dev, buf, size);
 		mutex_unlock(data, BOUNCE_MTX);


### PR DESCRIPTION
Hello Theodore,

after pulling 1.46.2 into Yocto project test matrix, regressions have appeared with mkfs.ext2. After bisecting the issue, this was found to be the offending commit:
https://github.com/tytso/e2fsprogs/commit/d557b9659ba97e093f842dcc7e2cfe9a7022c674

Upon closer inspection, I found two things that seem problematic in the commit, even without knowing the particularities of the code, and here are the patches for both of them. I can confirm that especially the partial revert of the sizes and offsets changes fixes the regressions we see.

Thanks,
Alexander