### PR TITLE
Fix POSIX ACL conversion on big endian machines

### DIFF
--- a/lib/ext2fs/ext_attr.c
+++ b/lib/ext2fs/ext_attr.c
@@ -556,10 +556,11 @@ static errcode_t convert_posix_acl_to_disk_buffer(const void *value, size_t size
 	s = sizeof(ext4_acl_header);
 	for (end = entry + count; entry != end;entry++) {
 		ext4_acl_entry *disk_entry = (ext4_acl_entry*) e;
-		disk_entry->e_tag = ext2fs_cpu_to_le16(entry->e_tag);
-		disk_entry->e_perm = ext2fs_cpu_to_le16(entry->e_perm);
 
-		switch(entry->e_tag) {
+		disk_entry->e_tag = entry->e_tag;
+		disk_entry->e_perm = entry->e_perm;
+
+		switch (ext2fs_le16_to_cpu(entry->e_tag)) {
 			case ACL_USER_OBJ:
 			case ACL_GROUP_OBJ:
 			case ACL_MASK:
@@ -569,7 +570,7 @@ static errcode_t convert_posix_acl_to_disk_buffer(const void *value, size_t size
 				break;
 			case ACL_USER:
 			case ACL_GROUP:
-				disk_entry->e_id =  ext2fs_cpu_to_le32(entry->e_id);
+				disk_entry->e_id = entry->e_id;
 				e += sizeof(ext4_acl_entry);
 				s += sizeof(ext4_acl_entry);
 				break;
@@ -608,10 +609,10 @@ static errcode_t convert_disk_buffer_to_posix_acl(const void *value, size_t size
 	while (size > 0) {
 		const ext4_acl_entry *disk_entry = (const ext4_acl_entry *) cp;
 
-		entry->e_tag = ext2fs_le16_to_cpu(disk_entry->e_tag);
-		entry->e_perm = ext2fs_le16_to_cpu(disk_entry->e_perm);
+		entry->e_tag = disk_entry->e_tag;
+		entry->e_perm = disk_entry->e_perm;
 
-		switch(entry->e_tag) {
+		switch (ext2fs_le16_to_cpu(entry->e_tag)) {
 			case ACL_USER_OBJ:
 			case ACL_GROUP_OBJ:
 			case ACL_MASK:
@@ -622,7 +623,7 @@ static errcode_t convert_disk_buffer_to_posix_acl(const void *value, size_t size
 				break;
 			case ACL_USER:
 			case ACL_GROUP:
-				entry->e_id = ext2fs_le32_to_cpu(disk_entry->e_id);
+				entry->e_id = disk_entry->e_id;
 				cp += sizeof(ext4_acl_entry);
 				size -= sizeof(ext4_acl_entry);
 				break;

--- a/lib/ext2fs/ext_attr.c
+++ b/lib/ext2fs/ext_attr.c
@@ -574,6 +574,8 @@ static errcode_t convert_posix_acl_to_disk_buffer(const void *value, size_t size
 				e += sizeof(ext4_acl_entry);
 				s += sizeof(ext4_acl_entry);
 				break;
+			default:
+				return EINVAL;
 		}
 	}
 	*size_out = s;
@@ -627,9 +629,9 @@ static errcode_t convert_disk_buffer_to_posix_acl(const void *value, size_t size
 				cp += sizeof(ext4_acl_entry);
 				size -= sizeof(ext4_acl_entry);
 				break;
-		default:
-			ext2fs_free_mem(&out);
-			return EINVAL;
+			default:
+				ext2fs_free_mem(&out);
+				return EINVAL;
 		}
 		entry++;
 	}


### PR DESCRIPTION
I got a test failure in `m_rootdir_acl` when building e2fsprogs 1.46.2 on powerpc64:

```patch
--- m_rootdir_acl/expect
+++ m_rootdir_acl.log
@@ -11,7 +11,7 @@
 Block count:              16384
 Reserved block count:     819
 Overhead clusters:        1543
-Free blocks:              14788
+Free blocks:              14789
 Free inodes:              1003
 First block:              1
 Block size:               1024
@@ -50,8 +50,8 @@
   Block bitmap at 130 (+129)
   Inode bitmap at 132 (+131)
   Inode table at 134-261 (+133)
-  7750 free blocks, 491 free inodes, 5 directories, 491 unused inodes
-  Free blocks: 443-8192
+  7751 free blocks, 491 free inodes, 5 directories, 491 unused inodes
+  Free blocks: 442-8192
   Free inodes: 22-512
 Group 1: (Blocks 8193-16383) [INODE_UNINIT]
   Backup superblock at 8193, Group descriptors at 8194-8194
@@ -105,15 +105,15 @@
 debugfs: ea_list acl_dir
 Extended attributes:
   system.data (0)
-  system.posix_acl_access (28) = 01 00 00 00 01 00 07 00 04 00 05 00 08 00 05 00 2a 00 00 00 10 00 05 00 20 00 05 00
-  system.posix_acl_default (28) = 01 00 00 00 01 00 07 00 04 00 05 00 08 00 05 00 04 00 00 00 10 00 05 00 20 00 05 00
+  system.posix_acl_access (4) = 01 00 00 00
+  system.posix_acl_default (4) = 01 00 00 00
 debugfs: ea_list acl_dir/file
 Extended attributes:
   system.data (0)
-  system.posix_acl_access (28) = 01 00 00 00 01 00 07 00 04 00 05 00 08 00 05 00 2a 00 00 00 10 00 05 00 20 00 05 00
+  system.posix_acl_access (4) = 01 00 00 00
 Pass 1: Checking inodes, blocks, and sizes
 Pass 2: Checking directory structure
 Pass 3: Checking directory connectivity
 Pass 4: Checking reference counts
 Pass 5: Checking group summary information
-test.img: 21/1024 files (0.0% non-contiguous), 1596/16384 blocks
+test.img: 21/1024 files (0.0% non-contiguous), 1595/16384 blocks
```

I am not very familiar with the on-disk ACL formats, but the code did not match the structure definitions, which use `__le16` and `__le32` everywhere. The test passes after applying these patches.

I'll note that even without applying 1e0c8ca7c08abb197aacb3ce78575ee5b00874b6, none of the other tests mentioned in #65 failed on powerpc64. And according to https://bugs.gentoo.org/790191, `m_rootdir_acl` is the only test failing on HPPA as well.