### PR TITLE
badblocks: fix operation with large block sizes and/or counts

### DIFF
--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -1055,7 +1055,7 @@ int main (int argc, char ** argv)
 	char * input_file = NULL;
 	char * output_file = NULL;
 	FILE * in = NULL;
-	int block_size = 1024;
+	unsigned int block_size = 1024;
 	unsigned int blocks_at_once = 64;
 	blk64_t last_block, first_block;
 	int num_passes = 0;
@@ -1203,9 +1203,9 @@ int main (int argc, char ** argv)
 			exit(1);
 		}
 	}
-	if ((block_size <= 0) || (block_size > (1 << 24)) ||
+	if ((block_size == 0) || (block_size > (1 << 24)) ||
 	    (block_size & (block_size - 1))) {
-		com_err(program_name, 0, _("Invalid block size: %d\n"),
+		com_err(program_name, 0, _("Invalid block size: %u\n"),
 			block_size);
 		exit(1);
 	}
@@ -1221,7 +1221,7 @@ int main (int argc, char ** argv)
 	device_name = argv[optind++];
 	if (optind > argc - 1) {
 		errcode = ext2fs_get_device_size2(device_name,
-						 block_size,
+						 (int) block_size,
 						 &last_block);
 		if (errcode == EXT2_ET_UNIMPLEMENTED) {
 			com_err(program_name, 0, "%s",
@@ -1351,7 +1351,7 @@ int main (int argc, char ** argv)
 	do {
 		unsigned int bb_count;
 
-		bb_count = test_func(dev, last_block, block_size,
+		bb_count = test_func(dev, last_block, (int) block_size,
 				     first_block, blocks_at_once);
 		if (bb_count)
 			passes_clean = 0;

--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -1036,9 +1036,12 @@ static unsigned int parse_uint(const char *str, const char *descr)
 
 	errno = 0;
 	ret = strtoul(str, &tmp, 0);
-	if (*tmp || errno || (ret > UINT_MAX) ||
-	    (ret == ULONG_MAX && errno == ERANGE)) {
+	if (*tmp || errno) {
 		com_err (program_name, 0, _("invalid %s - %s"), descr, str);
+		exit (1);
+	} else if ((ret > UINT_MAX) ||
+	    (ret == ULONG_MAX && errno == ERANGE)) {
+		com_err (program_name, 0, _("%s too large - %lu"), descr, ret);
 		exit (1);
 	}
 	return ret;

--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -389,7 +389,7 @@ static int do_read (int dev, unsigned char * buffer, int try, int block_size,
 	/* Try the read */
 	if (d_flag)
 		gettimeofday(&tv1, NULL);
-	got = read (dev, buffer, try * block_size);
+	got = read (dev, buffer, (size_t) try * block_size);
 	if (d_flag)
 		gettimeofday(&tv2, NULL);
 	if (got < 0)
@@ -460,7 +460,7 @@ static int do_write(int dev, unsigned char * buffer, int try, int block_size,
 		com_err (program_name, errno, "%s", _("during seek"));
 
 	/* Try the write */
-	got = write (dev, buffer, try * block_size);
+	got = write (dev, buffer, (size_t) try * block_size);
 	if (got < 0)
 		got = 0;
 	if (got & 511)
@@ -510,9 +510,9 @@ static unsigned int test_ro (int dev, blk_t last_block,
 	} while (next_bad && next_bad < first_block);
 
 	if (t_flag) {
-		blkbuf = allocate_buffer((blocks_at_once + 1) * block_size);
+		blkbuf = allocate_buffer(((size_t) blocks_at_once + 1) * block_size);
 	} else {
-		blkbuf = allocate_buffer(blocks_at_once * block_size);
+		blkbuf = allocate_buffer((size_t) blocks_at_once * block_size);
 	}
 	if (!blkbuf)
 	{
@@ -612,7 +612,7 @@ static unsigned int test_rw (int dev, blk_t last_block,
 	/* set up abend handler */
 	capture_terminate(NULL);
 
-	buffer = allocate_buffer(2 * blocks_at_once * block_size);
+	buffer = allocate_buffer((size_t) 2 * blocks_at_once * block_size);
 	read_buffer = buffer + blocks_at_once * block_size;
 
 	if (!buffer) {
@@ -771,7 +771,7 @@ static unsigned int test_nd (int dev, blk_t last_block,
 		ext2fs_badblocks_list_iterate (bb_iter, &next_bad);
 	} while (next_bad && next_bad < first_block);
 
-	blkbuf = allocate_buffer(3 * blocks_at_once * block_size);
+	blkbuf = allocate_buffer((size_t) 3 * blocks_at_once * block_size);
 	test_record = malloc(blocks_at_once * sizeof(struct saved_blk_record));
 	if (!blkbuf || !test_record) {
 		com_err(program_name, ENOMEM, "%s",
@@ -1213,7 +1213,8 @@ int main (int argc, char ** argv)
 		com_err(program_name, 0, _("Invalid number of blocks: %d\n"),
 			blocks_at_once);
 		exit(1);
-	} else if (((unsigned long long) block_size * blocks_at_once) > 0xFFFFFFFF) {
+	} else if (((size_t) block_size * blocks_at_once) > SIZE_MAX / 3) {
+		/* maximum usage is in test_nd() */
 		com_err(program_name, 0, _("For block size %d, number of blocks too large: %d\n"),
 			block_size, blocks_at_once);
 		exit(1);

--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -1209,10 +1209,13 @@ int main (int argc, char ** argv)
 			block_size);
 		exit(1);
 	}
-	if ((blocks_at_once <= 0) ||
-	    (((unsigned long long) block_size * blocks_at_once) > 0xFFFFFFFF)) {
-		com_err(program_name, 0, _("Invalid blocks_at_once: %d\n"),
+	if (blocks_at_once == 0) {
+		com_err(program_name, 0, _("Invalid number of blocks: %d\n"),
 			blocks_at_once);
+		exit(1);
+	} else if (((unsigned long long) block_size * blocks_at_once) > 0xFFFFFFFF) {
+		com_err(program_name, 0, _("For block size %d, number of blocks too large: %d\n"),
+			block_size, blocks_at_once);
 		exit(1);
 	}
 


### PR DESCRIPTION
Hi,

This PR fixes some issues I found when attempting to do a non-destructive read/write test on a hard drive. The default settings result in frequent seeking and overall low throughput, so my goal was to minimize seeking. Subject to memory constraints, reading/writing 2 GB at a time seemed reasonable, but I was unable to do so until making some changes.

Details are listed in each commit message.

Thanks,
Corey