### PR TITLE
mmp: Don't use O_RDWR in ext2fs_mmp_read

### DIFF
--- a/lib/ext2fs/mmp.c
+++ b/lib/ext2fs/mmp.c
@@ -58,7 +58,7 @@ errcode_t ext2fs_mmp_read(ext2_filsys fs, blk64_t mmp_blk, void *buf)
 	 * the MMP block by the io_manager or the VM.  It needs to be fresh. */
 	if (fs->mmp_fd <= 0) {
 		struct stat st;
-		int flags = O_RDWR | O_DIRECT;
+		int flags = O_DIRECT;
 
 		/*
 		 * There is no reason for using O_DIRECT if we're working with


### PR DESCRIPTION
It doesn't seem to be necessary since ext2fs_mmp_write doesn't write
via mmp_fd, and opening the block device with O_RDWR will trigger
udev.

Triggering udev is bad because it leads to an infinite loop when
running dumpe2fs in response to a udev event.