### PR TITLE
mke2fs: uid and gid of the copied inodes when using -d option

### DIFF
--- a/misc/create_inode.c
+++ b/misc/create_inode.c
@@ -967,6 +967,13 @@ find_lnf:
 			goto out;
 		}
 
+		if (fs_callbacks && fs_callbacks->new_inode_extra) {
+			retval = fs_callbacks->new_inode_extra(fs, target->path,
+				name, parent_ino, root, &st);
+			if (retval)
+				goto out;
+		}
+
 		retval = set_inode_extra(fs, ino, &st);
 		if (retval) {
 			com_err(__func__, retval,

--- a/misc/create_inode.h
+++ b/misc/create_inode.h
@@ -31,6 +31,9 @@ struct fs_ops_callbacks {
 	errcode_t (* end_create_new_inode)(ext2_filsys fs,
 		const char *target_path, const char *name,
 		ext2_ino_t parent_ino, ext2_ino_t root, mode_t mode);
+	errcode_t (* new_inode_extra)(ext2_filsys fs, const char *target_path,
+		const char *name, ext2_ino_t parent_ino, ext2_ino_t root,
+		struct stat *st);
 };
 
 extern int no_copy_xattrs; 	/* this should eventually be a flag

--- a/misc/mke2fs.8.in
+++ b/misc/mke2fs.8.in
@@ -842,6 +842,10 @@ sector size of the
 .B MKE2FS_SKIP_CHECK_MSG
 If set, do not show the message of filesystem automatic check caused by
 mount count or check interval.
+.TP
+.B MKE2FS_POPULATE_UID MKE2FS_POPULATE_GID
+With \fB-d\fR option, set UID and GID of the copied files in the newly created
+file system.
 .SH AUTHOR
 This version of
 .B mke2fs

--- a/misc/mke2fs.c
+++ b/misc/mke2fs.c
@@ -116,6 +116,9 @@ static int sync_kludge;	/* Set using the MKE2FS_SYNC env. option */
 char **fs_types;
 const char *src_root_dir;  /* Copy files from the specified directory */
 static char *undo_file;
+static int use_populate_id;
+static uid_t populate_uid;
+static gid_t populate_gid;
 
 static int android_sparse_file; /* -E android_sparse */
 
@@ -1665,6 +1668,16 @@ profile_error:
 			break;
 		case 'd':
 			src_root_dir = optarg;
+			tmp = getenv("MKE2FS_POPULATE_UID");
+			if (tmp) {
+				populate_uid = atoi(tmp);
+				use_populate_id = 1;
+			}
+			tmp = getenv("MKE2FS_POPULATE_GID");
+			if (tmp) {
+				populate_gid = atoi(tmp);
+				use_populate_id = 1;
+			}
 			break;
 		case 'D':
 			direct_io = 1;
@@ -2907,6 +2920,16 @@ try_user:
 	return 0;
 }
 
+errcode_t cb_populate_new_inode_extra (ext2_filsys fs, const char *target_path,
+	const char *name, ext2_ino_t parent_ino, ext2_ino_t root,
+	struct stat *st)
+{
+	st->st_uid = populate_uid;
+	st->st_gid = populate_gid;
+
+	return 0;
+}
+
 int main (int argc, char *argv[])
 {
 	errcode_t	retval = 0;
@@ -3369,11 +3392,18 @@ no_journal:
 		com_err(program_name, retval, "while creating huge files");
 	/* Copy files from the specified directory */
 	if (src_root_dir) {
+		struct fs_ops_callbacks fs_ops_callbacks;
+
+		memset(&fs_ops_callbacks, 0, sizeof(fs_ops_callbacks));
+		if (use_populate_id)
+			fs_ops_callbacks.new_inode_extra =
+				cb_populate_new_inode_extra;
+
 		if (!quiet)
 			printf("%s", _("Copying files into the device: "));
 
-		retval = populate_fs(fs, EXT2_ROOT_INO, src_root_dir,
-				     EXT2_ROOT_INO);
+		retval = populate_fs2(fs, EXT2_ROOT_INO, src_root_dir,
+				     EXT2_ROOT_INO, &fs_ops_callbacks);
 		if (retval) {
 			com_err(program_name, retval, "%s",
 				_("while populating file system"));


### PR DESCRIPTION
I've added MKE2FS_POPULATE_UID and MKE2FS_POPULATE_GID env vars for use with -d option so that I don't have to use root privileges to change the uid and gid when the contents of source root directory are not owned by root. `mksquashfs` sets the uid and gid to 0 by default. I wanted this feature in mke2fs as well.

I doubt the usefulness of these env vars as it seems no one really felt the need to implement these. I just wanted to put it out here so that someone can use my work.
