### PR TITLE
debugfs: dump: add rdump -p and handle attrs better

### DIFF
--- a/configure
+++ b/configure
@@ -13406,6 +13406,12 @@ then :
   printf "%s\n" "#define HAVE_UTIME 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "utimensat" "ac_cv_func_utimensat"
+if test "x$ac_cv_func_utimensat" = xyes
+then :
+  printf "%s\n" "#define HAVE_UTIMENSAT 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "utimes" "ac_cv_func_utimes"
 if test "x$ac_cv_func_utimes" = xyes
 then :

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -478,6 +478,9 @@
 /* Define to 1 if you have the `utime' function. */
 #undef HAVE_UTIME
 
+/* Define to 1 if you have the `utimensat' function. */
+#undef HAVE_UTIMENSAT
+
 /* Define to 1 if you have the `utimes' function. */
 #undef HAVE_UTIMES
 


### PR DESCRIPTION
This change is part of a contribution I made to erofs-utils on the fsck.erofs --extract=X option.
Timestamps should always be preserved as they are safe to preserve, regardless of user type.
This isn't the case for chmod/chown, which is only allowed to be used by root.

debugfs is used by different kinds of users (e.g. AOSP build system) since rdump is the only official way to dump the contents of an ext2/3/4 image.
The dump command already has the -p option, which lets non-root users omit to avoid an "operation not permitted" vomit all over the terminal, but rdump still pukes all the way.
AOSP knows this, they use rdump in their "deapexer" Python utility, and their way of handling this is just swallowing all output to both stdout and stderr, and only printing it out if the execution failed. This change brings the -p flag to rdump, and root users who actually need it can use it. Normal users simply can't avoid it, as it stands now.

The other change was making sure access/mod timestamps are preserved properly, since "utime" and "chown" try to dereference symlinks and thus not acting on the symlinks themselves. Using "utimensat" when available, and "lchown" instead of "chown" will avoid this error.

All this is already used in erofs-utils. I think we should sync this to e2fsprogs.
Feel free to change what you feel necessary.