### PR TITLE
ext2fs: Use 64-bit lseek when SIZEOF_OFF_T is 64bits

### DIFF
--- a/lib/blkid/llseek.c
+++ b/lib/blkid/llseek.c
@@ -50,7 +50,7 @@ extern long long llseek(int fd, long long offset, int origin);
 
 #else	/* ! HAVE_LLSEEK */
 
-#if SIZEOF_LONG == SIZEOF_LONG_LONG
+#if SIZEOF_OFF_T == SIZEOF_LONG_LONG
 
 #define llseek lseek
 

--- a/lib/ext2fs/llseek.c
+++ b/lib/ext2fs/llseek.c
@@ -51,7 +51,7 @@ extern long long llseek (int fd, long long offset, int origin);
 
 #else	/* ! HAVE_LLSEEK */
 
-#if SIZEOF_LONG == SIZEOF_LONG_LONG || _FILE_OFFSET_BITS+0 == 64
+#if SIZEOF_OFF_T == SIZEOF_LONG_LONG
 
 #define my_llseek lseek
 


### PR DESCRIPTION
musl-1.2.4 no longer defines lseek64, and since off_t is always 64-bits, autoconf decides to not pass in -D_FILE_OFFSET_BITS=64 when compiling, and this results in a compilation failure.

Instead of checking _FILE_OFFSET_BITS=64, let's just check if SIZEOF_OFF_T is SIZEOF_LONG_LONG. Also, SIZEOF_LONG is irrelevant.