### PR TITLE
debugfs: fix endless loop in rdump

### DIFF
--- a/debugfs/dump.c
+++ b/debugfs/dump.c
@@ -122,8 +122,10 @@ static void dump_file(const char *cmdname, ext2_ino_t ino, int fd,
 	}
 	while (1) {
 		retval = ext2fs_file_read(e2_file, buf, blocksize, &got);
-		if (retval)
+		if (retval) {
 			com_err(cmdname, retval, "while reading ext2 file");
+			return;
+		}
 		if (got == 0)
 			break;
 		nbytes = write(fd, buf, got);


### PR DESCRIPTION
When recursively dumping the content of an ext2 filesystem where extended attribute value conflicts with key using `rdump / /tmp/out`, debugfs get's in an endless loop.

This is due to the fact that we only break out of the while(1) loop if the 'got' value is 0, which never happens when an error is encountered.

The applied fix mimics what happens when retval is non-zero and returns.

This can be tested with an existing test sample from e2fsprogs (see `tests/f_ea_value_crash/image.gz`).

Behavior prior to this patch:

```
$ mkdir -p /tmp/out
$ gunzip tests/f_ea_value_crash/image.gz
$ ./debugfs/debugfs -R 'rdump / /tmp/out' tests/f_ea_value_crash/image
debugfs 1.47.0 (5-Feb-2023)
rdump: Extended attribute has an invalid value offset while reading ext2 file
rdump: Extended attribute has an invalid value offset while reading ext2 file
rdump: Extended attribute has an invalid value offset while reading ext2 file
rdump: Extended attribute has an invalid value offset while reading ext2 file
--endless loop here--
```
