### PR TITLE
lib/ext2fs: llseek: simplify linux section

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1116,6 +1116,7 @@ AC_CHECK_DECL(fsmap_sizeof,[AC_DEFINE(HAVE_FSMAP_SIZEOF, 1,
 dnl
 dnl Word sizes...
 dnl
+AC_SYS_LARGEFILE
 AC_CHECK_SIZEOF(short)
 AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(long)
@@ -1900,8 +1901,6 @@ OS_IO_FILE=""
   ;;
 esac]
 AC_SUBST(OS_IO_FILE)
-
-AC_SYS_LARGEFILE
 
 dnl
 dnl Make our output files, being sure that we create the some miscellaneous 

--- a/lib/ext2fs/llseek.c
+++ b/lib/ext2fs/llseek.c
@@ -35,68 +35,32 @@
 
 #ifdef __linux__
 
-#if defined(HAVE_LSEEK64) && defined(HAVE_LSEEK64_PROTOTYPE)
-
-#define my_llseek lseek64
-
-#else
-#if defined(HAVE_LLSEEK)
-#include <sys/syscall.h>
-
-#ifndef HAVE_LLSEEK_PROTOTYPE
-extern long long llseek (int fd, long long offset, int origin);
-#endif
-
-#define my_llseek llseek
-
-#else	/* ! HAVE_LLSEEK */
-
-#if SIZEOF_LONG == SIZEOF_LONG_LONG || _FILE_OFFSET_BITS+0 == 64
-
-#define my_llseek lseek
-
-#else /* SIZEOF_LONG != SIZEOF_LONG_LONG */
-
 #include <linux/unistd.h>
-
-#ifndef __NR__llseek
-#define __NR__llseek            140
-#endif
-
-#ifndef __i386__
-static int _llseek (unsigned int, unsigned long,
-		   unsigned long, ext2_loff_t *, unsigned int);
-
-static _syscall5(int,_llseek,unsigned int,fd,unsigned long,offset_high,
-		 unsigned long, offset_low,ext2_loff_t *,result,
-		 unsigned int, origin);
-#endif
 
 static ext2_loff_t my_llseek (int fd, ext2_loff_t offset, int origin)
 {
-	ext2_loff_t result;
+#if SIZEOF_OFF_T >= 8
+	return lseek(fd, offset, origin);
+#elif HAVE_LSEEK64_PROTOTYPE
+	return lseek64(fd, offset, origin);
+#elif HAVE_LLSEEK_PROTOTYPE
+	return llseek(fd, offset, origin);
+#elif defined(__NR__llseek)
+	loff_t result;
 	int retval;
-
-#ifndef __i386__
-	retval = _llseek(fd, ((unsigned long long) offset) >> 32,
+	retval = syscall(__NR__llseek, fd,
+		(unsigned long)(offset >> 32),
+		(unsigned long)(offset & 0xffffffff),
+		&result, origin);
+	return (retval == -1 ? retval : result);
 #else
-	retval = syscall(__NR__llseek, fd, (unsigned long long) (offset >> 32),
+	errno = ENOSYS;
+	return -1;
 #endif
-			  ((unsigned long long) offset) & 0xffffffff,
-			&result, origin);
-	return (retval == -1 ? (ext2_loff_t) retval : result);
 }
-
-#endif	/* SIZE_LONG == SIZEOF_LONG_LONG */
-
-#endif /* HAVE_LLSEEK */
-#endif /* defined(HAVE_LSEEK64) && defined(HAVE_LSEEK64_PROTOTYPE) */
 
 ext2_loff_t ext2fs_llseek (int fd, ext2_loff_t offset, int origin)
 {
-#if SIZEOF_OFF_T >= SIZEOF_LONG_LONG
-	return my_llseek (fd, offset, origin);
-#else
 	ext2_loff_t result;
 	static int do_compat = 0;
 
@@ -117,7 +81,6 @@ ext2_loff_t ext2fs_llseek (int fd, ext2_loff_t offset, int origin)
 		return -1;
 	}
 	return result;
-#endif
 }
 
 #else /* !linux */


### PR DESCRIPTION
This PR supersedes [#144](https://github.com/tytso/e2fsprogs/pull/144).

On 32-bit musl systems, off_t is always 8 bytes regardless of _FILE_OFFSET_BITS. The previous code did not cover this case.

The previous #ifdef logic was rather confusing, so I reworked it into a more understandable form.