### PR TITLE
badblocks: improved status output when bad block is found

### DIFF
--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -91,6 +91,7 @@ static unsigned int d_flag;		/* delay factor between reads */
 static struct timeval time_start;
 
 #define T_INC 32
+#define S_BUF 128
 
 static unsigned int sys_page_size = 4096;
 
@@ -155,9 +156,20 @@ static void *allocate_buffer(size_t size)
 static int bb_output (blk_t bad, enum error_types error_type)
 {
 	errcode_t errcode;
+	char status_buf[S_BUF];
 
 	if (ext2fs_badblocks_list_test(bb_list, bad))
 		return 0;
+
+	if (v_flag > 1) {
+		memset(status_buf, ' ', S_BUF-1);
+		status_buf[S_BUF-1] = 0;
+		fputs(status_buf, stderr);
+		memset(status_buf, '\b', S_BUF-1);
+		status_buf[S_BUF-1] = 0;      /* Not strictly needed but safe */
+		fputs(status_buf, stderr);
+		fflush (stderr);
+	}
 
 	fprintf(out, "%lu\n", (unsigned long) bad);
 	fflush(out);
@@ -218,9 +230,9 @@ static float calc_percent(unsigned long current, unsigned long total) {
 static void print_status(void)
 {
 	struct timeval time_end;
-	char diff_buf[32], line_buf[128];
+	char diff_buf[32], line_buf[S_BUF];
 #ifdef HAVE_MBSTOWCS
-	wchar_t wline_buf[128];
+	wchar_t wline_buf[S_BUF];
 #endif
 	int len;
 


### PR DESCRIPTION
When `badblocks` finds a bad block and the `-vv` option is used, the output is garbled. This fixes it.

The following is the output from a test with bad blocks 1024 and 2048.

Before: 
```
$ sudo misc/badblocks -vv /dev/sda1
Checking blocks 0 to 204799
Checking for bad blocks (read-only test): 102450% done, 0:00 elapsed. (0/0/0 errors)
204800% done, 0:00 elapsed. (1/0/0 errors)
done                                                 
Pass completed, 2 bad blocks found. (2/0/0 errors)
```

After:
```
$ sudo misc/badblocks -vv /dev/sda1
Checking blocks 0 to 204799
Checking for bad blocks (read-only test): 1024                                                                                                                           
2048                                                                                                                           
done                                                 
Pass completed, 2 bad blocks found. (2/0/0 errors)
```

Signed-off-by: Laurent Chardon <laurent.chardon@gmail.com>