### PR TITLE
Set fixed times for inode to make sure that we can have reproducible builds

### DIFF
--- a/misc/create_inode.c
+++ b/misc/create_inode.c
@@ -125,9 +125,14 @@ static errcode_t set_inode_extra(ext2_filsys fs, ext2_ino_t ino,
 	inode.i_gid = st->st_gid;
 	ext2fs_set_i_gid_high(inode, st->st_gid >> 16);
 	inode.i_mode = (LINUX_S_IFMT & inode.i_mode) | (~S_IFMT & st->st_mode);
-	inode.i_atime = st->st_atime;
-	inode.i_mtime = st->st_mtime;
-	inode.i_ctime = st->st_ctime;
+
+	if (fs->now) {
+		inode.i_atime = inode.i_mtime = inode.i_ctime = fs->now;
+	} else {
+		inode.i_atime = st->st_atime;
+		inode.i_mtime = st->st_mtime;
+		inode.i_ctime = st->st_ctime;
+	}
 
 	retval = ext2fs_write_inode(fs, ino, &inode);
 	if (retval)


### PR DESCRIPTION
There's a small issue that has to be fixed if you'd like to be able to create a reproducible ext4 FS from the source directory.
By default, **https://reproducible-builds.org/docs/system-images/** suggests you:

> Instead of using mkfs.ext, make_ext4fs can be used. make_ext4fs is creating the whole filesystem at once. 

Yes, **make_ext4fs** can create a reproducible FSes, but it lacks the proper hard links support (I'm about to send patches that fix this issue as well, so in the end everyone has a choice to use either **mkfs.ext4** or **make_ext4fs,** but the latter to the best of my knowledge has been phased out ).

You can try to test these changes by first trying to create a reproducible FS from the stand alone structure 2 times in a row and compare SHA256 hashes of the result image (or block device, whatever you choose to use):
````
$ E2FSPROGS_FAKE_TIME=0x4f5b6f7c e2fsprogs/build/misc/mke2fs -E hash_seed=440aa176-97fa-475a-8209-d96eff4a0c90 -t ext4 -b 4K -U clear 576M_3.3.16.0.bin -d 3.3.16.0.proper.var`
````
You'll notice that the result images will differ.

Then apply this tiny change and repeat, this time you can see that both images are identical.

P.S. There might be cases (say, by using different options) that could still lead to FS being not reproducible. In that case I suggest to handle them on the need-to-do basis (once the problem is reported).
