### PR TITLE
Add root_perms extended mke2fs option.

### DIFF
--- a/misc/mke2fs.8.in
+++ b/misc/mke2fs.8.in
@@ -406,6 +406,11 @@ The \fBroot_owner=\fR option allows explicitly specifying these values,
 and avoid side-effects for users that do not expect the contents of the
 file system to change based on the user running \fBmke2fs\fR.
 .TP
+.BI root_perms [=permissions]
+Specify the root directory permissions in octal format. If no permissions
+are specified then the root directory permissions would be set in accordance with
+the default filesystem umask.
+.TP
 .B test_fs
 Set a flag in the file system superblock indicating that it may be
 mounted using experimental kernel code, such as the ext4dev file system.

--- a/misc/mke2fs.c
+++ b/misc/mke2fs.c
@@ -90,6 +90,7 @@ static int	force;
 static int	noaction;
 static int	num_backups = 2; /* number of backup bg's for sparse_super2 */
 static uid_t	root_uid;
+static mode_t 	root_perms = (mode_t)-1;
 static gid_t	root_gid;
 int	journal_size;
 int	journal_flags;
@@ -469,6 +470,7 @@ static void create_root_dir(ext2_filsys fs)
 {
 	errcode_t		retval;
 	struct ext2_inode	inode;
+	int need_inode_change;
 
 	retval = ext2fs_mkdir(fs, EXT2_ROOT_INO, EXT2_ROOT_INO, 0);
 	if (retval) {
@@ -476,19 +478,30 @@ static void create_root_dir(ext2_filsys fs)
 			_("while creating root dir"));
 		exit(1);
 	}
-	if (root_uid != 0 || root_gid != 0) {
+
+	need_inode_change = (int)(root_uid != 0 || root_gid != 0 || root_perms != (mode_t)-1);
+
+	if (need_inode_change) {
 		retval = ext2fs_read_inode(fs, EXT2_ROOT_INO, &inode);
 		if (retval) {
 			com_err("ext2fs_read_inode", retval, "%s",
 				_("while reading root inode"));
 			exit(1);
 		}
+	}
 
+	if (root_uid != 0 || root_gid != 0) {
 		inode.i_uid = root_uid;
 		ext2fs_set_i_uid_high(inode, root_uid >> 16);
 		inode.i_gid = root_gid;
 		ext2fs_set_i_gid_high(inode, root_gid >> 16);
+	}
 
+	if (root_perms != (mode_t)-1) {
+		inode.i_mode = LINUX_S_IFDIR | root_perms;
+	}
+
+	if (need_inode_change) {
 		retval = ext2fs_write_new_inode(fs, EXT2_ROOT_INO, &inode);
 		if (retval) {
 			com_err("ext2fs_write_inode", retval, "%s",
@@ -1048,6 +1061,10 @@ static void parse_extended_opts(struct ext2_super_block *param,
 				root_uid = getuid();
 				root_gid = getgid();
 			}
+		} else if (!strcmp(token, "root_perms")) {
+			if (arg) {
+				root_perms = strtoul(arg, &p, 8);
+			}
 		} else if (!strcmp(token, "discard")) {
 			discard = 1;
 		} else if (!strcmp(token, "nodiscard")) {
@@ -1132,6 +1149,7 @@ static void parse_extended_opts(struct ext2_super_block *param,
 			"\tlazy_itable_init=<0 to disable, 1 to enable>\n"
 			"\tlazy_journal_init=<0 to disable, 1 to enable>\n"
 			"\troot_owner=<uid of root dir>:<gid of root dir>\n"
+			"\troot_perms=<octal root directory permissions>\n"
 			"\ttest_fs\n"
 			"\tdiscard\n"
 			"\tnodiscard\n"

--- a/tests/m_root_perms/expect.1
+++ b/tests/m_root_perms/expect.1
@@ -1,0 +1,57 @@
+Creating filesystem with 1024 1k blocks and 128 inodes
+
+Allocating group tables:    done                            
+Writing inode tables:    done                            
+Writing superblocks and filesystem accounting information:    done
+
+Filesystem features: ext_attr resize_inode dir_index filetype sparse_super
+Pass 1: Checking inodes, blocks, and sizes
+Pass 2: Checking directory structure
+Pass 3: Checking directory connectivity
+Pass 4: Checking reference counts
+Pass 5: Checking group summary information
+test_filesys: 11/128 files (0.0% non-contiguous), 54/1024 blocks
+Exit status is 0
+Filesystem volume name:   <none>
+Last mounted on:          <not available>
+Filesystem magic number:  0xEF53
+Filesystem revision #:    1 (dynamic)
+Filesystem features:      ext_attr resize_inode dir_index filetype sparse_super
+Default mount options:    (none)
+Filesystem state:         clean
+Errors behavior:          Continue
+Filesystem OS type:       Linux
+Inode count:              128
+Block count:              1024
+Reserved block count:     51
+Overhead clusters:        40
+Free blocks:              970
+Free inodes:              117
+First block:              1
+Block size:               1024
+Fragment size:            1024
+Reserved GDT blocks:      3
+Blocks per group:         8192
+Fragments per group:      8192
+Inodes per group:         128
+Inode blocks per group:   32
+Mount count:              0
+Check interval:           15552000 (6 months)
+Reserved blocks uid:      0
+Reserved blocks gid:      0
+First inode:              11
+Inode size:	          256
+Required extra isize:     32
+Desired extra isize:      32
+Default directory hash:   half_md4
+
+
+Group 0: (Blocks 1-1023)
+  Primary superblock at 1, Group descriptors at 2-2
+  Reserved GDT blocks at 3-5
+  Block bitmap at 6 (+5)
+  Inode bitmap at 7 (+6)
+  Inode table at 8-39 (+7)
+  970 free blocks, 117 free inodes, 2 directories
+  Free blocks: 54-1023
+  Free inodes: 12-128

--- a/tests/m_root_perms/script
+++ b/tests/m_root_perms/script
@@ -1,0 +1,4 @@
+DESCRIPTION="root directory permissions"
+FS_SIZE=1024
+MKE2FS_OPTS="-E root_perms=0464"
+. $cmd_dir/run_mke2fs


### PR DESCRIPTION
This options allows user to specify custom root dir permissions at FS creation time. If no perms are specified then the root dir permissions would be set to default.

This is related to https://github.com/tytso/e2fsprogs/issues/168

@tytso could you review this please?