### PR TITLE
misc/mke2fs.c: suppress 'Creating regular file' message with -q

### DIFF
--- a/misc/mke2fs.c
+++ b/misc/mke2fs.c
@@ -2073,7 +2073,8 @@ profile_error:
 			dev_size = 0;
 			retval = 0;
 			close(fd);
-			printf(_("Creating regular file %s\n"), device_name);
+			if (!quiet)
+				printf(_("Creating regular file %s\n"), device_name);
 		}
 	}
 	if (retval && (retval != EXT2_ET_UNIMPLEMENTED)) {


### PR DESCRIPTION
To check if the installed version of mke2fs is able to accept tarballs, I'm piping 10240 null-bytes (an empty tarball) into mke2fs. Unfortunately, mke2fs prints this on stdout:

    Creating regular file [...]

and the `-q` flag has no effect. An easy workaround is to touch the file before running mke2fs but it would be nice if that were not necessary.