### PR TITLE
mke2fs: enable copying of fs-verity metadata

### DIFF
--- a/configure
+++ b/configure
@@ -11977,6 +11977,12 @@ then :
   printf "%s\n" "#define HAVE_LINUX_FSMAP_H 1" >>confdefs.h
 
 fi
+ac_fn_c_check_header_compile "$LINENO" "linux/fsverity.h" "ac_cv_header_linux_fsverity_h" "$ac_includes_default"
+if test "x$ac_cv_header_linux_fsverity_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_LINUX_FSVERITY_H 1" >>confdefs.h
+
+fi
 ac_fn_c_check_header_compile "$LINENO" "linux/major.h" "ac_cv_header_linux_major_h" "$ac_includes_default"
 if test "x$ac_cv_header_linux_major_h" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -1009,6 +1009,7 @@ AC_CHECK_HEADERS(m4_flatten([
 	linux/falloc.h
 	linux/fd.h
 	linux/fsmap.h
+	linux/fsverity.h
 	linux/major.h
 	linux/loop.h
 	linux/types.h

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -199,6 +199,9 @@
 /* Define to 1 if you have the <linux/fsmap.h> header file. */
 #undef HAVE_LINUX_FSMAP_H
 
+/* Define to 1 if you have the <linux/fsverity.h> header file. */
+#undef HAVE_LINUX_FSVERITY_H
+
 /* Define to 1 if you have the <linux/loop.h> header file. */
 #undef HAVE_LINUX_LOOP_H
 

--- a/misc/create_inode.c
+++ b/misc/create_inode.c
@@ -599,18 +599,18 @@ static errcode_t copy_file(ext2_filsys fs, int fd, struct stat *statbuf,
 
 #if defined(SEEK_DATA) && defined(SEEK_HOLE)
 	err = try_lseek_copy(fs, fd, statbuf, e2_file, buf, zerobuf);
-	if (err != EXT2_ET_UNIMPLEMENTED)
-		goto out;
+#else
+	err = EXT2_ET_UNIMPLEMENTED;
 #endif
 
 #if defined(FS_IOC_FIEMAP)
-	err = try_fiemap_copy(fs, fd, e2_file, buf, zerobuf);
-	if (err != EXT2_ET_UNIMPLEMENTED)
-		goto out;
+	if (err == EXT2_ET_UNIMPLEMENTED)
+		err = try_fiemap_copy(fs, fd, e2_file, buf, zerobuf);
 #endif
 
-	err = copy_file_chunk(fs, fd, e2_file, 0, statbuf->st_size, buf,
-			      zerobuf);
+	if (err == EXT2_ET_UNIMPLEMENTED)
+		err = copy_file_chunk(fs, fd, e2_file, 0, statbuf->st_size, buf,
+				      zerobuf);
 out:
 	ext2fs_free_mem(&zerobuf);
 	ext2fs_free_mem(&buf);

--- a/misc/mke2fs.c
+++ b/misc/mke2fs.c
@@ -2385,6 +2385,14 @@ profile_error:
 		exit(1);
 	}
 
+	/* fs-verity support requires extents */
+	if (ext2fs_has_feature_verity(&fs_param) &&
+	    !ext2fs_has_feature_extents(&fs_param)) {
+		printf("%s", _("Extents MUST be enabled for fs-verity "
+			       "support.  Pass -O extents to rectify.\n"));
+		exit(1);
+	}
+
 	/* Set first meta blockgroup via an environment variable */
 	/* (this is mostly for debugging purposes) */
 	if (ext2fs_has_feature_meta_bg(&fs_param) &&


### PR DESCRIPTION
When creating a filesystem with `mke2fs -O verity` and populating content via `-d`, check if that content is fs-verity enabled, and if it is, copy the fs-verity metadata from the host-native filesystem into the created filesystem.
    
This currently doesn't work for reading from btrfs, which fails to implement the required ioctl(), but it will work between two ext4 filesystems.
    
Closes #201

Input greatly appreciated!

 - [ ] the current code checks for fs-verity on a file after reading and copying the data contents and sets the `EXT4_VERITY_FL` flag after the fact.  Most of the other flags are set ahead of time.  We could check the file flags for `FS_VERITY_FL` with `FS_IOC_GETFLAGS` to help with that, but it's a matter of taste.  I sort of prefer the current approach
 - [ ] after copying the verity data we need to rewrite the inode to fixup the size and ~version fields~flags, currently.  The way this is done in the patch is very ugly, mostly because I'm not familiar with the code.  Help appreciated
 - [x] ~we ought to document why we need to set the version field to 2.  I was only able to discover that by dumping the inode on a file on a real filesystem that I mounted and ran `fsverity enable` on and looking for differences vs. the filesystem created by `mke2fs -d`.~ this was probably caused by inconsistencies in the test environment
 - [x] This doesn't work with btrfs (which is what my work laptop with Fedora is using) due to a missing ioctl.  See https://lore.kernel.org/fsverity/20241125084111.141386-1-allison.karlitskaya@redhat.com/T/#u for a fix.  *edit:* This has gone in for -next: https://github.com/btrfs/linux/commit/0af58a673817a31f13eabde179b8271922765083
 - [x] fix crash when specifying `-O verity` without `-t ext4`: `Copying files into the device: mke2fs: create_inode.c:698: copy_fs_verity: Assertion 'inode.i_flags & EXT4_EXTENTS_FL' failed.`
