### PR TITLE
fix incorrectly packaged symlink in spec files

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,1 +1,1 @@
-doc/RelNotes/v1.47.0.txt
+doc/RelNotes/v1.47.2.txt

--- a/e2fsprogs.spec
+++ b/e2fsprogs.spec
@@ -67,6 +67,8 @@ SMP systems.
 make
 make check
 
+rel_notes=$(readlink RELEASE-NOTES); rm -f RELEASE-NOTES && cp $rel_notes RELEASE-NOTES
+
 %install
 rm -rf $RPM_BUILD_ROOT
 export PATH=/sbin:$PATH


### PR DESCRIPTION
In the spec file, the RELEASE-NOTES to be packaged is a symbolic link. We need to replace it with the real file.

![image](https://github.com/user-attachments/assets/53360dec-2f54-4d7d-828b-38ad5bdaa347)

And update the target of RELEASE-NOTES to 1.47.2

