### PR TITLE
Add a callback for overriding ext2fs_process_dir_block().

### DIFF
--- a/lib/ext2fs/dblist_dir.c
+++ b/lib/ext2fs/dblist_dir.c
@@ -79,9 +79,9 @@ static int db_dir_proc(ext2_filsys fs, struct ext2_db_entry2 *db_info,
 	if (inode.i_flags & EXT4_INLINE_DATA_FL)
 		ret = ext2fs_inline_data_dir_iterate(fs, ctx->dir, ctx);
 	else
-		ret = ext2fs_process_dir_block(fs, &db_info->blk,
-					       db_info->blockcnt, 0, 0,
-					       priv_data);
+		(fs->process_dir_block ? fs->process_dir_block :
+		 ext2fs_process_dir_block)(fs, &db_info->blk,
+					   db_info->blockcnt, 0, 0, priv_data);
 	if ((ret & BLOCK_ABORT) && !ctx->errcode)
 		return DBLIST_ABORT;
 	return 0;

--- a/lib/ext2fs/dir_iterate.c
+++ b/lib/ext2fs/dir_iterate.c
@@ -124,6 +124,8 @@ errcode_t ext2fs_dir_iterate2(ext2_filsys fs,
 	ctx.priv_data = priv_data;
 	ctx.errcode = 0;
 	retval = ext2fs_block_iterate3(fs, dir, BLOCK_FLAG_READ_ONLY, 0,
+				       fs->process_dir_block ?
+				       fs->process_dir_block :
 				       ext2fs_process_dir_block, &ctx);
 	if (!block_buf)
 		ext2fs_free_mem(&ctx.buf);

--- a/lib/ext2fs/dir_iterate.c
+++ b/lib/ext2fs/dir_iterate.c
@@ -315,3 +315,25 @@ next:
 		return retval | BLOCK_ABORT;
 	return retval;
 }
+
+void ext2fs_set_process_dir_block_callback(ext2_filsys fs,
+                			   int (*func)(ext2_filsys fs,
+                                                       blk64_t *blocknr,
+                                                       e2_blkcnt_t blockcnt,
+                                                       blk64_t ref_block,
+                                                       int ref_offset,
+                                                       void *priv_data),
+                                           int (**old)(ext2_filsys fs,
+                                                       blk64_t *blocknr,
+                                                       e2_blkcnt_t blockcnt,
+                                                       blk64_t ref_block,
+                                                       int ref_offset,
+                                                       void *priv_data))
+{
+        if (!fs || fs->magic != EXT2_ET_MAGIC_EXT2FS_FILSYS)
+                return;
+        if (old)
+                *old = fs->process_dir_block;
+
+        fs->process_dir_block = func;
+}

--- a/lib/ext2fs/ext2fs.h
+++ b/lib/ext2fs/ext2fs.h
@@ -305,6 +305,9 @@ struct struct_ext2_filsys {
 	errcode_t (*get_alloc_block2)(ext2_filsys fs, blk64_t goal,
 				      blk64_t *ret, struct blk_alloc_ctx *ctx);
 	void (*block_alloc_stats)(ext2_filsys fs, blk64_t blk, int inuse);
+	int (*process_dir_block)(ext2_filsys fs, blk64_t *blocknr,
+	     e2_blkcnt_t blockcnt, blk64_t ref_block, int ref_offset,
+	     void *priv_data);
 
 	/*
 	 * Buffers for Multiple mount protection(MMP) block.

--- a/lib/ext2fs/ext2fs.h
+++ b/lib/ext2fs/ext2fs.h
@@ -305,9 +305,6 @@ struct struct_ext2_filsys {
 	errcode_t (*get_alloc_block2)(ext2_filsys fs, blk64_t goal,
 				      blk64_t *ret, struct blk_alloc_ctx *ctx);
 	void (*block_alloc_stats)(ext2_filsys fs, blk64_t blk, int inuse);
-	int (*process_dir_block)(ext2_filsys fs, blk64_t *blocknr,
-	     e2_blkcnt_t blockcnt, blk64_t ref_block, int ref_offset,
-	     void *priv_data);
 
 	/*
 	 * Buffers for Multiple mount protection(MMP) block.
@@ -340,6 +337,11 @@ struct struct_ext2_filsys {
 	struct ext2fs_hashmap* block_sha_map;
 
 	const struct ext2fs_nls_table *encoding;
+
+	/* ext2fs_process_dir_block() hook */
+	int (*process_dir_block)(ext2_filsys fs, blk64_t *blocknr,
+	     e2_blkcnt_t blockcnt, blk64_t ref_block, int ref_offset,
+	     void *priv_data);
 };
 
 #if EXT2_FLAT_INCLUDES

--- a/lib/ext2fs/ext2fs.h
+++ b/lib/ext2fs/ext2fs.h
@@ -860,6 +860,11 @@ extern void ext2fs_set_block_alloc_stats_range_callback(ext2_filsys fs,
 				    blk_t num, int inuse),
 	void (**old)(ext2_filsys fs, blk64_t blk,
 				    blk_t num, int inuse));
+extern void ext2fs_set_process_dir_block_callback(ext2_filsys fs,
+        int (*func)(ext2_filsys fs, blk64_t *blocknr, e2_blkcnt_t blockcnt,
+                    blk64_t ref_block, int ref_offset, void *priv_data),
+	int (**old)(ext2_filsys fs, blk64_t *blocknr, e2_blkcnt_t blockcnt,
+                    blk64_t ref_block, int ref_offset, void *priv_data));
 #define EXT2_NEWRANGE_FIXED_GOAL	(0x1)
 #define EXT2_NEWRANGE_MIN_LENGTH	(0x2)
 #define EXT2_NEWRANGE_ALL_FLAGS		(0x3)

--- a/lib/ext2fs/inline_data.c
+++ b/lib/ext2fs/inline_data.c
@@ -154,7 +154,8 @@ int ext2fs_inline_data_dir_iterate(ext2_filsys fs, ext2_ino_t ino,
 	dirent.name[1] = '\0';
 	ctx->buf = (char *)&dirent;
 	ext2fs_get_rec_len(fs, &dirent, &ctx->buflen);
-	ret |= ext2fs_process_dir_block(fs, 0, blockcnt++, 0, 0, priv_data);
+	ret |= (fs->process_dir_block ? fs->process_dir_block :
+		ext2fs_process_dir_block)(fs, 0, blockcnt++, 0, 0, priv_data);
 	if (ret & BLOCK_ABORT)
 		goto out;
 
@@ -166,7 +167,8 @@ int ext2fs_inline_data_dir_iterate(ext2_filsys fs, ext2_ino_t ino,
 	dirent.name[2] = '\0';
 	ctx->buf = (char *)&dirent;
 	ext2fs_get_rec_len(fs, &dirent, &ctx->buflen);
-	ret |= ext2fs_process_dir_block(fs, 0, blockcnt++, 0, 0, priv_data);
+	ret |= (fs->process_dir_block ? fs->process_dir_block :
+		ext2fs_process_dir_block)(fs, 0, blockcnt++, 0, 0, priv_data);
 	if (ret & BLOCK_INLINE_DATA_CHANGED) {
 		errcode_t err;
 
@@ -188,7 +190,8 @@ int ext2fs_inline_data_dir_iterate(ext2_filsys fs, ext2_ino_t ino,
 		goto out;
 	}
 #endif
-	ret |= ext2fs_process_dir_block(fs, 0, blockcnt++, 0, 0, priv_data);
+	ret |= (fs->process_dir_block ? fs->process_dir_block :
+		ext2fs_process_dir_block)(fs, 0, blockcnt++, 0, 0, priv_data);
 	if (ret & BLOCK_INLINE_DATA_CHANGED) {
 #ifdef WORDS_BIGENDIAN
 		ctx->errcode = ext2fs_dirent_swab_out2(fs, ctx->buf,
@@ -226,7 +229,8 @@ int ext2fs_inline_data_dir_iterate(ext2_filsys fs, ext2_ino_t ino,
 	}
 #endif
 
-	ret |= ext2fs_process_dir_block(fs, 0, blockcnt++, 0, 0, priv_data);
+	ret |= (fs->process_dir_block ? fs->process_dir_block :
+		ext2fs_process_dir_block)(fs, 0, blockcnt++, 0, 0, priv_data);
 	if (ret & BLOCK_INLINE_DATA_CHANGED) {
 #ifdef WORDS_BIGENDIAN
 		ctx->errcode = ext2fs_dirent_swab_out2(fs, ctx->buf,

--- a/lib/ext2fs/link.c
+++ b/lib/ext2fs/link.c
@@ -289,7 +289,8 @@ static errcode_t add_dirent_to_buf(ext2_filsys fs, e2_blkcnt_t blockcnt,
 	ls.blocksize = fs->blocksize;
 	ls.err = 0;
 
-	ext2fs_process_dir_block(fs, pblkp, blockcnt, 0, 0, &ctx);
+	(fs->process_dir_block ? fs->process_dir_block :
+	 ext2fs_process_dir_block)(fs, pblkp, blockcnt, 0, 0, &ctx);
 	if (ctx.errcode)
 		return ctx.errcode;
 	if (ls.err)


### PR DESCRIPTION
We have an application which creates a filesystem, creates many files in many directories on the filesystem, and performs no other operations on the filesystem. Creating a file in a directory is a quadratic-time operation using e2fsprogs because ext2fs_link() must do a linear scan of the directory to find the extent to put an inode in. For us this will always be the last extent.

The dominant operation in the linear directory scan is ext2fs_process_dir_block() because it performs I/O. The callback will let us keep track of the block number of the last extent in the directory and only call ext2fs_process_dir_block() on the last extent, except if the directory was just expanded using ext2fs_expand_dir(), in which case the full scan is necessary, but rare. This improves the performance of adding 100,000 files to a directory by 8x for us.