### PR TITLE
Improve wording on inaccurate warning message

### DIFF
--- a/misc/fuse2fs.c
+++ b/misc/fuse2fs.c
@@ -3889,7 +3889,8 @@ int main(int argc, char *argv[])
 
 	if (!fctx.ro) {
 		if (ext2fs_has_feature_journal(global_fs->super))
-			printf(_("%s: Writing to the journal is not supported.\n"),
+			printf(_("%s: Journal is enabled, but fuse2fs does not support using it."
+				 " Data loss may occur if not gracefully unmounted.\n"),
 			       fctx.device);
 		err = ext2fs_read_inode_bitmap(global_fs);
 		if (err) {


### PR DESCRIPTION
When mounting a filesystem with fuse2fs, a warning message indicates that writing to the journal is not supported. This can be interpreted as the filesystem lacking a journal.

Clarify this message by being explicit in that fuse2fs does not support journaling.

**DRAFT: this patch is a draft; the POT file need to be regenerated, but I'm not sure how to do so. Awaiting feedback on this.**

See: https://github.com/tytso/e2fsprogs/issues/220