### PR TITLE
lib: use getauxval(AT_SECURE) for SUID check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1015,6 +1015,7 @@ AC_CHECK_HEADERS(m4_flatten([
 	net/if_dl.h
 	netinet/in.h
 	sys/acl.h
+	sys/auxv.h
 	sys/disklabel.h
 	sys/disk.h
 	sys/file.h

--- a/lib/blkid/cache.c
+++ b/lib/blkid/cache.c
@@ -19,6 +19,9 @@
 #endif
 #include <stdlib.h>
 #include <string.h>
+#ifdef HAVE_SYS_AUXV_H
+#include <sys/auxv.h> // for getauxval()
+#endif
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #else
@@ -37,8 +40,13 @@ int blkid_debug_mask = 0;
 
 static char *safe_getenv(const char *arg)
 {
+#if defined(HAVE_SYS_AUXV_H) && defined(AT_SECURE)
+	if (getauxval(AT_SECURE))
+		return NULL;
+#else
 	if ((getuid() != geteuid()) || (getgid() != getegid()))
 		return NULL;
+#endif
 #if HAVE_PRCTL
 	if (prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0)
 		return NULL;

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -409,6 +409,9 @@
 /* Define to 1 if you have the <sys/acl.h> header file. */
 #undef HAVE_SYS_ACL_H
 
+/* Define to 1 if you have the <sys/auxv.h> header file. */
+#undef HAVE_SYS_AUXV_H
+
 /* Define to 1 if you have the <sys/disklabel.h> header file. */
 #undef HAVE_SYS_DISKLABEL_H
 

--- a/lib/et/error_message.c
+++ b/lib/et/error_message.c
@@ -21,6 +21,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#ifdef HAVE_SYS_AUXV_H
+#include <sys/auxv.h> // for getauxval()
+#endif
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #else
@@ -204,8 +207,13 @@ oops:
 static char *safe_getenv(const char *arg)
 {
 #if !defined(_WIN32)
+#if defined(HAVE_SYS_AUXV_H) && defined(AT_SECURE)
+	if (getauxval(AT_SECURE))
+		return NULL;
+#else
 	if ((getuid() != geteuid()) || (getgid() != getegid()))
 		return NULL;
+#endif
 #endif
 #if HAVE_PRCTL
 	if (prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0)

--- a/lib/ext2fs/getenv.c
+++ b/lib/ext2fs/getenv.c
@@ -22,6 +22,9 @@
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_SYS_AUXV_H
+#include <sys/auxv.h> // for getauxval()
+#endif
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #else
@@ -35,8 +38,13 @@
 
 char *ext2fs_safe_getenv(const char *arg)
 {
+#if defined(HAVE_SYS_AUXV_H) && defined(AT_SECURE)
+	if (getauxval(AT_SECURE))
+		return NULL;
+#else
 	if ((getuid() != geteuid()) || (getgid() != getegid()))
 		return NULL;
+#endif
 #ifdef HAVE_PRCTL
 	if (prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0)
 		return NULL;

--- a/lib/ss/pager.c
+++ b/lib/ss/pager.c
@@ -27,6 +27,9 @@
 #include <sys/types.h>
 #include <sys/file.h>
 #include <signal.h>
+#ifdef HAVE_SYS_AUXV_H
+#include <sys/auxv.h> // for getauxval()
+#endif
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #else
@@ -41,8 +44,13 @@ extern char *getenv PROTOTYPE((const char *));
 
 char *ss_safe_getenv(const char *arg)
 {
+#if defined(HAVE_SYS_AUXV_H) && defined(AT_SECURE)
+	if (getauxval(AT_SECURE))
+		return NULL;
+#else
 	if ((getuid() != geteuid()) || (getgid() != getegid()))
 		return NULL;
+#endif
 #if HAVE_PRCTL
 	if (prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) == 0)
 		return NULL;


### PR DESCRIPTION
Comparing effective and real uid/gid is not a proper way to check for SUID execution:

1. this does not consider file capabilities

2. this check breaks when NO_NEW_PRIVS is used as the Linux kernel resets effective ids during execve(); this means the check is false, but the process still has raised capabilities

For more details about the NO_NEW_PRIVS problem, check this post and the surrounding thread:

 https://lore.kernel.org/lkml/20250509184105.840928-1-max.kellermann@ionos.com/