### PR TITLE
e2scrub: Fix return code check for lvremove

### DIFF
--- a/scrub/e2scrub.in
+++ b/scrub/e2scrub.in
@@ -182,7 +182,7 @@ snap_dev="/dev/${LVM2_VG_NAME}/${snap}"
 teardown() {
 	# Remove and wait for removal to succeed.
 	${DBG} lvremove -f "${LVM2_VG_NAME}/${snap}"
-	while [ -e "${snap_dev}" ] && [ "$?" -eq "5" ]; do
+	while [ "$?" -eq "5" ] && [ -e "${snap_dev}" ]; do
 		sleep 0.5
 		${DBG} lvremove -f "${LVM2_VG_NAME}/${snap}"
 	done
@@ -210,7 +210,7 @@ setup() {
 	# Try to remove snapshot for 30s, bail out if we can't remove it.
 	lvremove_deadline="$(( $(date "+%s") + 30))"
 	${DBG} lvremove -f "${LVM2_VG_NAME}/${snap}" 2>/dev/null
-	while [ -e "${snap_dev}" ] && [ "$?" -eq "5" ] &&
+	while [ "$?" -eq "5" ] && [ -e "${snap_dev}" ] &&
 	      [ "$(date "+%s")" -lt "${lvremove_deadline}" ]; do
 		sleep 0.5
 		${DBG} lvremove -f "${LVM2_VG_NAME}/${snap}"


### PR DESCRIPTION
### Fix incorrect exit status check after lvremove in e2scrub

This PR fixes a bug in e2scrub where the exit status check for `lvremove` was incorrectly testing the return value of the `[ -e "${snap_dev}" ]` condition instead of the actual `lvremove` command. By reordering the conditions to check `$?` first, we ensure that we're properly detecting when `lvremove` fails with exit code 5 (which typically indicates the device is busy).

I noticed this logic was not correct recently when running e2scrub on a snapshot that I had mounted partitions via `kpartx`. This caused `lvremove` to output "Device busy" and fail, but instead of waiting in the while loop, the script immediately exited. This change fixes that.