### PR TITLE
e2scrub: Make fstrim optional

### DIFF
--- a/scrub/e2scrub@.service.in
+++ b/scrub/e2scrub@.service.in
@@ -16,5 +16,5 @@ User=root
 IOSchedulingClass=idle
 CPUSchedulingPolicy=idle
 Environment=SERVICE_MODE=1
-ExecStart=@root_sbindir@/e2scrub -t %f
+ExecStart=@root_sbindir@/e2scrub %f
 SyslogIdentifier=%N


### PR DESCRIPTION
The service file calls `e2scrub` with the `-t` flag which overrides the `fstrim` setting in `/etc/e2scrub.conf`. I don't see the point in forcing an fstrim for every scrub as systemd already comes with a built in `fstrim.timer` enabled.

Removing the `-t` flag will give the user the option to do as they please.