### PR TITLE
Badblocks: return non-zero on any read/write/corruption error

### DIFF
--- a/misc/badblocks.c
+++ b/misc/badblocks.c
@@ -1375,5 +1375,5 @@ int main (int argc, char ** argv)
 	if (out != stdout)
 		fclose (out);
 	free(t_patts);
-	return 0;
+	return !!(!passes_clean || num_read_errors || num_write_errors || num_corruption_errors);
 }


### PR DESCRIPTION
Badblocks always returns 0, which does not allow to use it for scripting for media validation.
Return 1 in case of any issue with the media.