### PR TITLE
Fix Buffer Overflow in mke2fs test_disk Function

### DIFF
--- a/misc/mke2fs.c
+++ b/misc/mke2fs.c
@@ -238,12 +238,17 @@ static void test_disk(ext2_filsys fs, badblocks_list *bb_list)
 {
 	FILE		*f;
 	errcode_t	retval;
+	int len;
 	char		buf[1024];
 
-	sprintf(buf, "badblocks -b %d -X %s%s%s %llu", fs->blocksize,
-		quiet ? "" : "-s ", (cflag > 1) ? "-w " : "",
-		fs->device_name,
-		(unsigned long long) ext2fs_blocks_count(fs->super)-1);
+	len = snprintf(buf, sizeof(buf), "badblocks -b %d -X %s%s%s %llu", fs->blocksize,
+         quiet ? "" : "-s ", (cflag > 1) ? "-w " : "",
+         fs->device_name,
+         (unsigned long long) ext2fs_blocks_count(fs->super)-1);
+	if (len >= sizeof(buf)) {
+		com_err(program_name, 0, _("Device name too long for badblocks command"));
+		exit(1);
+	}
 	if (verbose)
 		printf(_("Running command: %s\n"), buf);
 	f = popen(buf, "r");


### PR DESCRIPTION
## Summary

Fix critical buffer overflow vulnerability in test_disk() function where unbounded sprintf() can write beyond the 1024-byte buffer when processing long device names.

## Description

The sprintf() call at line 258 in mke2fs.c constructs a command string without bounds checking:

```c
char buf[1024];
sprintf(buf, "badblocks -b %d -X %s%s%s %llu", fs->blocksize,
    quiet ? "" : "-s ", (cflag > 1) ? "-w " : "",
    fs->device_name,
    (unsigned long long) ext2fs_blocks_count(fs->super)-1);
```
Potential for stack-based buffer overflow with device names > ~950 characters.

## Patch

Replace sprintf() with snprintf() for bounds checking and add proper error handling for oversized command strings.

