### PR TITLE
fuse2fs: revert change of storing boolean options in bytes instead of ints

### DIFF
--- a/misc/fuse2fs.c
+++ b/misc/fuse2fs.c
@@ -217,17 +217,17 @@ struct fuse2fs {
 	pthread_mutex_t bfl;
 	char *device;
 	char *shortdev;
-	uint8_t ro;
-	uint8_t debug;
-	uint8_t no_default_opts;
-	uint8_t panic_on_error;
-	uint8_t minixdf;
-	uint8_t fakeroot;
-	uint8_t alloc_all_blocks;
-	uint8_t norecovery;
-	uint8_t kernel;
-	uint8_t directio;
-	uint8_t acl;
+	int ro;
+	int debug;
+	int no_default_opts;
+	int panic_on_error;
+	int minixdf;
+	int fakeroot;
+	int alloc_all_blocks;
+	int norecovery;
+	int kernel;
+	int directio;
+	int acl;
 
 	int logfd;
 	int blocklog;


### PR DESCRIPTION
This reverts commit c7f2688540d95e7f2cbcd178f8ff62ebe079faf7 which turned the ints into uint8_t but didn't realize that fuse_opt_parse() assumes they are ints.

- Fixes #245