### PR TITLE
misc/create_inode.c: Fix for file larger than 2GB

### DIFF
--- a/misc/create_inode.c
+++ b/misc/create_inode.c
@@ -414,7 +414,7 @@ static ssize_t my_pread(int fd, void *buf, size_t count, off_t offset)
 }
 #endif /* !defined HAVE_PREAD64 && !defined HAVE_PREAD */
 
-static errcode_t write_all(ext2_file_t e2_file, ext2_off_t off, const char *buf, unsigned int n_bytes) {
+static errcode_t write_all(ext2_file_t e2_file, __u64 off, const char *buf, unsigned int n_bytes) {
 	errcode_t err = ext2fs_file_llseek(e2_file, off, EXT2_SEEK_SET, NULL);
 	if (err)
 		return err;


### PR DESCRIPTION
Fixed:
$ dd if=/dev/zero of=../image.ext4 bs=1M count=4k
$ dd if=/dev/random of=../rootfs/largefile bs=1M count=3k
$ ./misc/mke2fs -t ext4 -d ../rootfs/ ../image.ext4
__populate_fs: Ext2 file too big while writing file "largefile"
mke2fs: Ext2 file too big while populating file system

This was because the offset is overflow, use __u64 to fix the problem.

Another code which uses ext2_off_t is copy_fs_verity_data(), but it only copies the metadata, so it should be enough large for it, just leave it there.