### PR TITLE
fix discard const qualifier from pointers

### DIFF
--- a/lib/blkid/tag.c
+++ b/lib/blkid/tag.c
@@ -225,16 +225,17 @@ errout:
 int blkid_parse_tag_string(const char *token, char **ret_type, char **ret_val)
 {
 	char *name, *value, *cp;
+	const char *tokenp;
 
 	DBG(DEBUG_TAG, printf("trying to parse '%s' as a tag\n", token));
 
-	if (!token || !(cp = strchr(token, '=')))
+	if (!token || !(tokenp = strchr(token, '=')))
 		return -1;
 
 	name = blkid_strdup(token);
 	if (!name)
 		return -1;
-	value = name + (cp - token);
+	value = name + (tokenp - token);
 	*value++ = '\0';
 	if (*value == '"' || *value == '\'') {
 		char c = *value++;

--- a/lib/support/profile.c
+++ b/lib/support/profile.c
@@ -394,8 +394,8 @@ errcode_t profile_set_default(profile_t profile, const char *def_string)
 	struct parse_state	state;
 	prf_file_t		prf;
 	errcode_t		retval;
-	const char		*in;
-	char			*line, *p, *end;
+	const char		*in, *end;
+	char			*line, *p;
 	int			line_size, len;
 
 	if (!def_string || !profile || profile->magic != PROF_MAGIC_PROFILE)

--- a/misc/create_inode.c
+++ b/misc/create_inode.c
@@ -339,7 +339,7 @@ errcode_t do_mknod_internal(ext2_filsys fs, ext2_ino_t cwd, const char *name,
 #endif
 
 /* Make a symlink name -> target */
-errcode_t do_symlink_internal(ext2_filsys fs, ext2_ino_t cwd, const char *name,
+errcode_t do_symlink_internal(ext2_filsys fs, ext2_ino_t cwd, char *name,
 			      char *target, ext2_ino_t root)
 {
 	char			*cp;
@@ -375,7 +375,7 @@ errcode_t do_symlink_internal(ext2_filsys fs, ext2_ino_t cwd, const char *name,
 }
 
 /* Make a directory in the fs */
-errcode_t do_mkdir_internal(ext2_filsys fs, ext2_ino_t cwd, const char *name,
+errcode_t do_mkdir_internal(ext2_filsys fs, ext2_ino_t cwd, char *name,
 			    unsigned long flags, ext2_ino_t root)
 {
 	char			*cp;
@@ -766,7 +766,7 @@ static int is_hardlink(struct hdlinks_s *hdlinks, dev_t dev, ino_t ino)
 
 /* Copy the native file to the fs */
 errcode_t do_write_internal(ext2_filsys fs, ext2_ino_t cwd, const char *src,
-			    const char *dest, unsigned long flags,
+			    char *dest, unsigned long flags,
 			    ext2_ino_t root)
 {
 	int		fd;
@@ -943,7 +943,7 @@ static errcode_t __populate_fs(ext2_filsys fs, ext2_ino_t parent_ino,
 			       int flags,
 			       struct fs_ops_callbacks *fs_callbacks)
 {
-	const char	*name;
+	char		*name;
 	struct dirent	**dent;
 	struct stat	st;
 	unsigned long	fl;

--- a/misc/create_inode.h
+++ b/misc/create_inode.h
@@ -57,13 +57,13 @@ extern errcode_t do_mknod_internal(ext2_filsys fs, ext2_ino_t cwd,
 				   const char *name, unsigned int st_mode,
 				   unsigned int st_rdev);
 extern errcode_t do_symlink_internal(ext2_filsys fs, ext2_ino_t cwd,
-				     const char *name, char *target,
+				     char *name, char *target,
 				     ext2_ino_t root);
 extern errcode_t do_mkdir_internal(ext2_filsys fs, ext2_ino_t cwd,
-				   const char *name, unsigned long flags,
+				   char *name, unsigned long flags,
 				   ext2_ino_t root);
 extern errcode_t do_write_internal(ext2_filsys fs, ext2_ino_t cwd,
-				   const char *src, const char *dest,
+				   const char *src, char *dest,
 				   unsigned long flags, ext2_ino_t root);
 extern errcode_t add_link(ext2_filsys fs, ext2_ino_t parent_ino,
 			  ext2_ino_t ino, const char *name);

--- a/misc/e4crypt.c
+++ b/misc/e4crypt.c
@@ -144,7 +144,7 @@ static int hex2byte(const char *hex, size_t hex_size, unsigned char *bytes,
 		    size_t bytes_size)
 {
 	size_t x;
-	unsigned char *h, *l;
+	const unsigned char *h, *l;
 
 	if (hex_size % 2)
 		return -EINVAL;
@@ -301,7 +301,7 @@ static void parse_salt(char *salt_str, int flags)
 		cp += 2;
 		goto salt_from_filename;
 	} else if (strncmp(cp, "0x", 2) == 0) {
-		unsigned char *h, *l;
+		const unsigned char *h, *l;
 
 		cp += 2;
 		if (strlen(cp) & 1)


### PR DESCRIPTION
Since glibc-2.43 and ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

- create_inode: fix discard const qualifier from pointer
- libblkid: fix discard const qualifier from pointer
- libsupport: fix discard const qualifier from pointer
- e4crypt: fix discard const qualifier from pointer