### PR TITLE
ib: ext2fs: fix prevent buffer overflow in ext2fs_add_journal_device in mkjournal.c

### DIFF
--- a/lib/ext2fs/mkjournal.c
+++ b/lib/ext2fs/mkjournal.c
@@ -457,7 +457,7 @@ errcode_t ext2fs_add_journal_device(ext2_filsys fs, ext2_filsys journal_dev)
 
 	/* Check and see if this filesystem has already been added */
 	nr_users = ntohl(jsb->s_nr_users);
-	if (nr_users > JBD2_USERS_MAX)
+	if (nr_users >= JBD2_USERS_MAX)
 		return EXT2_ET_CORRUPT_JOURNAL_SB;
 	for (i=0; i < nr_users; i++) {
 		if (memcmp(fs->super->s_uuid,


### PR DESCRIPTION

The check `if (nr_users > JBD2_USERS_MAX)` allowed nr_users to equal JBD2_USERS_MAX (48), which leads to a buffer overflow when writing a new user UUID:

    memcpy(&jsb->s_users[nr_users*16], fs->super->s_uuid, 16);

Since s_users is defined as [JBD2_USERS_MAX][16], valid indices are 0..47. When nr_users==48, the expression nr_users*16 evaluates to 768, causing a 16-byte write beyond the array boundary (valid range: 0..767).

Change the condition to `>=` to reject nr_users values that would result in an out-of-bounds access.

Reported-by: static analysis tool

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>
