### PR TITLE
e2fsck: validate fast commit dentry tag length

### DIFF
--- a/e2fsck/journal.c
+++ b/e2fsck/journal.c
@@ -621,6 +621,9 @@ static inline int tl_to_darg(struct dentry_info_args *darg,
 {
 	struct ext4_fc_dentry_info fcd;
 
+	if (ext4_fc_tag_len(tl) < sizeof(struct ext4_fc_dentry_info))
+		return -EINVAL;
+
 	memcpy(&fcd, val, sizeof(fcd));
 
 	darg->parent_ino = le32_to_cpu(fcd.fc_parent_ino);


### PR DESCRIPTION
## Summary

In `tl_to_darg()`, the function copies `sizeof(struct ext4_fc_dentry_info)` bytes from the tag value buffer without first checking that the tag's data length is at least that large. A crafted filesystem with a truncated `EXT4_FC_TAG_LINK`, `EXT4_FC_TAG_UNLINK`, or `EXT4_FC_TAG_CREAT` tag triggers a heap buffer over-read (and potentially a stack buffer under-read when computing the filename length via subtraction).

Add a bounds check rejecting tags shorter than the fixed-size dentry info header before the `memcpy`.

## Testing

Built and verified the fix compiles cleanly against current master. Confirmed the vulnerable path is reachable by processing a crafted ext4 image with fast commit journal entries.