### PR TITLE
lib: Fix parallel library build ordering

### DIFF
--- a/lib/Makefile.elf-lib
+++ b/lib/Makefile.elf-lib
@@ -22,6 +22,13 @@ ELF_SONAME = $(ELF_IMAGE).so.$(ELF_SO_VERSION)
 
 image:		$(ELF_LIB)
 
+# The static library makefile fragment also defines "all::" without a recipe.
+# With GNU make, a later no-recipe "all:: image" rule is not sufficient to make
+# "make all" visit this fragment's prerequisite. Tie the ELF image to the
+# static archive target so normal subdirectory builds create both outputs
+# before returning to the parent recursive make.
+$(LIBRARY).a: image
+
 $(ELF_LIB): $(OBJS)
 	$(E) "	GEN_ELF_SOLIB $(ELF_LIB)"
 	$(Q) (cd elfshared; $(CC) -o $(ELF_LIB) \

--- a/lib/ss/Makefile.in
+++ b/lib/ss/Makefile.in
@@ -58,7 +58,7 @@ SRCS=	$(srcdir)/invocation.c $(srcdir)/help.c \
 	$(srcdir)/list_rqs.c $(srcdir)/pager.c $(srcdir)/requests.c \
 	$(srcdir)/data.c $(srcdir)/get_readline.c
 
-all:: mk_cmds
+all:: mk_cmds libss.a ss.pc
 
 @MAKEFILE_LIBRARY@
 @MAKEFILE_ELF@
@@ -105,6 +105,8 @@ ss_err.c ss_err.h: ss_err.et
 	$(E) "	COMPILE_ET ss_err.et"
 	$(Q) $(COMPILE_ET) $(srcdir)/ss_err.et
 
+ss_err.h: ss_err.c
+
 ct.tab.c ct.tab.h: ct.y
 	$(RM) -f ct.tab.* y.*
 	$(YACC) -d $(srcdir)/ct.y
@@ -136,6 +138,9 @@ install:: libss.a $(INSTALL_HFILES) installdirs ss_err.h mk_cmds ss.pc
 	$(Q) $(INSTALL_DATA) libss.a $(DESTDIR)$(libdir)/libss.a
 	-$(Q) $(RANLIB) $(DESTDIR)$(libdir)/libss.a
 	$(Q) $(CHMOD) $(LIBMODE) $(DESTDIR)$(libdir)/libss.a
+	$(Q) $(MKDIR_P) $(DESTDIR)$(includedir)/ss \
+		$(DESTDIR)$(datadir)/ss $(DESTDIR)$(bindir) \
+		$(DESTDIR)$(pkgconfigdir) $(DESTDIR)$(man1dir)
 	$(Q) $(RM) -f $(DESTDIR)$(includedir)/ss/*
 	$(Q) for i in $(INSTALL_HFILES); do \
 		echo "	INSTALL_DATA $(DESTDIR)$(includedir)/ss/$$i"; \


### PR DESCRIPTION
I'm currently building with a 56 core machine and hitting these issues with master branch, commit 43643a57fb2d3368fbacd181a8cd713102d52a1a.
Fixes and reasoning are in the patch.

Using these configure parameters:
```
[...]configure \
    --enable-elf-shlibs \
    --disable-libuuid \
    --disable-uuidd \
    --disable-libblkid \
    --enable-verbose-makecmds
```

And then `make -j56`:
```
make[2]: *** No rule to make target '../lib/libext2fs.so', needed by 'e2fsck'. Stop.
make[2]: *** Waiting for unfinished jobs....
gcc -c -I. -I../lib -I../../src/lib  -g -O2 -pthread  -DHAVE_CONFIG_H  ../../src/e2fsck/encrypted_files.c -o encrypted_files.o
make[2]: Leaving directory '/tmp/e2fsprogs-master-race.yfQYqM/build/e2fsck'
make[1]: *** [Makefile:445: all-progs-recursive] Error 1
make[1]: Leaving directory '/tmp/e2fsprogs-master-race.yfQYqM/build'
make: *** [Makefile:373: all] Error 2
```

Logs:
[configure.log](https://github.com/user-attachments/files/29050932/configure.log)
[make.log](https://github.com/user-attachments/files/29050808/make.log)