### PR TITLE
Fix my_llseek error when targeting 32bit musl libc

### DIFF
--- a/lib/blkid/llseek.c
+++ b/lib/blkid/llseek.c
@@ -50,7 +50,7 @@ extern long long llseek(int fd, long long offset, int origin);
 
 #else	/* ! HAVE_LLSEEK */
 
-#if SIZEOF_LONG == SIZEOF_LONG_LONG
+#if SIZEOF_LONG == SIZEOF_LONG_LONG || SIZEOF_OFF_T == 8
 
 #define my_llseek lseek
 


### PR DESCRIPTION
remove workaround when 64bit filetypes are used

fix: #277