### PR TITLE
mke2fs: tolerate unsupported xattrs in mke2fs -d

### DIFF
--- a/misc/create_inode.c
+++ b/misc/create_inode.c
@@ -204,6 +204,8 @@ static errcode_t set_inode_xattr(ext2_filsys fs, ext2_ino_t ino,
 
 		value_size = lgetxattr(filename, name, NULL, 0);
 		if (value_size == -1) {
+			if (errno == ENOTSUP)
+				continue;
 			retval = errno;
 			com_err(__func__, retval,
 				_("while reading attribute \"%s\" of \"%s\""),
@@ -220,6 +222,8 @@ static errcode_t set_inode_xattr(ext2_filsys fs, ext2_ino_t ino,
 		value_size = lgetxattr(filename, name, value, value_size);
 		if (value_size == -1) {
 			ext2fs_free_mem(&value);
+			if (errno == ENOTSUP)
+				continue;
 			retval = errno;
 			com_err(__func__, retval,
 				_("while reading attribute \"%s\" of \"%s\""),


### PR DESCRIPTION
When populating a filesystem image with "mke2fs -d", set_inode_xattr() copies the extended attributes of each source file. If llistxattr() fails with ENOTSUP it simply returns 0 and copies no attributes.

However, if llistxattr() reports an attribute name but the subsequent lgetxattr() fails with ENOTSUP, the whole copy is aborted and mke2fs returns with an error. This can happen when running mke2fs inside a sandboxed environment running on an SELinux-enabled host. Processes in the sandbox see, but cannot read, the "security.selinux" label from host files.

The fix is just to extend the existing ENOTSUP tolerance to the per-attribute lgetxattr() calls.