### PR TITLE
libe2p: Fix fgetflags assigning uninitialized value when ioctl fails

### DIFF
--- a/lib/e2p/fgetflags.c
+++ b/lib/e2p/fgetflags.c
@@ -105,7 +105,8 @@ int fgetflags (const char * name, unsigned long * flags)
 			errno = EOPNOTSUPP;
 		save_errno = errno;
 	}
-	*flags = f;
+	else
+	    *flags = f;
 	close(fd);
 	if (save_errno)
 		errno = save_errno;


### PR DESCRIPTION
This fixes issue #271 in which `fgetflags()` assigns an uninitialized value to `*flags` when `ioctl()` fails.

This patch only sets `*flags` to `f` when `ioctl()`'s return value isn't `-1` and so `f` has been assigned a value by `ioctl()`. Otherwise, it leaves `*flags` untouched, as expected by the user.